### PR TITLE
fix: optional chain operationData to allow global contexts

### DIFF
--- a/packages/api-platform-types/package.json
+++ b/packages/api-platform-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamnovu/kit-api-platform-types",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Frontend typescript types for API Platform",
   "exports": {
     ".": {

--- a/packages/api-platform-types/src/plugin/generateSerializationGroups/parser/yaml.ts
+++ b/packages/api-platform-types/src/plugin/generateSerializationGroups/parser/yaml.ts
@@ -135,11 +135,11 @@ export async function loadOperationSerializationGroups(inputDir: string): Promis
         const operationGroupDefinitions: ParsedOperationSerializationGroupsPropertyDefinition[] = []
 
         for (const [operationKey, operationData] of operations) {
-          const operationClass = operationData.class ?? operationKey
+          const operationClass = operationData?.class ?? operationKey
           const hasInput = ['ApiPlatform\\Metadata\\Patch', 'ApiPlatform\\Metadata\\Post', 'ApiPlatform\\Metadata\\Put'].includes(operationClass)
 
-          const inputGroups = hasInput ? operationData.denormalizationContext?.groups ?? globalInputGroups : null
-          const outputGroups = operationData.normalizationContext?.groups ?? globalOutputGroups
+          const inputGroups = hasInput ? operationData?.denormalizationContext?.groups ?? globalInputGroups : null
+          const outputGroups = operationData?.normalizationContext?.groups ?? globalOutputGroups
 
           // if there is a name set, use this instead of the key
           const improvedOperationName = operationData?.name ?? operationKey.replaceAll('\\', '').replace('ApiPlatformMetadata', '')

--- a/packages/api-platform-types/src/plugin/generateSerializationGroups/parser/yaml.ts
+++ b/packages/api-platform-types/src/plugin/generateSerializationGroups/parser/yaml.ts
@@ -57,7 +57,7 @@ interface MappingFileContent {
             groups?: string[]
           }
           class?: string
-        }
+        } | null
       }
     }
   }


### PR DESCRIPTION
# Pull request

<!-- Write a short description of the change that you are submitting. -->

## Creators Checklist

Thanks for your Contribution 🎉

Before you request a review, please check the following:

- [ ] If you worked on a Jira Task: did you move the task to the review state?
- [ ] If you worked on a Jira Task: did you name the PR containing the task ID?
- [ ] Did you fullfill the business case? (Check the Jira task again to be sure).
- [ ] Did you cleanup your codebase (remove unused and commented code, remove dumps, [ray usages](https://github.com/Napp/xray-laravel) and console logs)?
- [ ] If needed: did you write any tests and do they pass?
- [ ] Did you push the latest changes?
- [ ] Did you check for merge conflicts?

## Reviewers Checklist

This list should help you to review your pull request:
- [ ] Did you check the code is readable and maintainable (complexity!)?
- [ ] Did you check code and comments for typos?
- [ ] If possible: did you check the code matches the requested business case?
- [ ] Did all tests pass?
- [ ] For big PRs: Did you smoke test it in your local test environment?

**After the PR is merged:**
- [ ] Did you delete the PR branch?
- [ ] Did you mark the Jira task as done?
- [ ] Was the deployment successful?




<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `loadOperationSerializationGroups` to handle null operation mapping entries
> In [yaml.ts](https://github.com/teamnovu/kit/pull/14/files#diff-5c88b942dee46a81a6035d7943da02903ad92df6ef56b747b408fceffe5392a3), operations in the mapping file can now have `null` values to represent global contexts. Previously, accessing properties on a null entry would throw at runtime.
>
> - Adds optional chaining when reading `operationData.class`, `operationData.denormalizationContext`, and `operationData.normalizationContext`.
> - When `operationData` is null, `operationClass` falls back to the operation key, and input/output groups fall back to the global group contexts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bf88f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->