### PR TITLE
Rework initial data handling such that fields further down the tree know about intial data changes further up the tree

### DIFF
--- a/packages/vue-forms/CHANGELOG.md
+++ b/packages/vue-forms/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-19
+
+### Added
+
+- `setInitialData` now accepts an options argument:
+  - `{ replace: true }` replaces the subtree wholesale instead of deep-merging with the external `initialData`.
+  - `{ scope: 'subtree' }` anchors the new baseline only for the targeted path and its descendants, so ancestors keep reading the external `initialData` and stay dirty when the override changes the tree shape (e.g. a new array item). `scope: 'tree'` (default) preserves the previous global-baseline behavior.
+- `useFieldArray` now exposes `pushPristine(item)` — like `push`, but anchors the new index's subtree as its own baseline so the new item's subfields start non-dirty while the array field itself stays dirty.
+
+### Changed
+
+- Initial-data resolution moved from a per-field local baseline into a form-level override layer (`useInitialDataOverride`). Overrides set via `setInitialData` on a parent path now propagate down to subfields, deep-merging with the external `initialData` by default.
+- `form.reset()` rebuilds `data` from the merged tree (external `initialData` + active overrides), so prior `setInitialData` calls survive a reset and act as the new programmatic baseline.
+- Reassigning the external `initialData` ref passed to `useForm` clears all active overrides.
+- Calling `setInitialData` on a path drops any existing override on that path or below before applying the new one.
+
 ## [0.2.18] - 2025-03-03
 
 ### Fixed

--- a/packages/vue-forms/docs/reference.md
+++ b/packages/vue-forms/docs/reference.md
@@ -130,6 +130,34 @@ setInitialData(fetchedData.firstName)
 // If the field wasn't dirty, the current data is also updated
 ```
 
+### Calling `setInitialData` on a parent path
+Overrides set on a parent path propagate down to its subfields. The default behavior is a **deep merge** with the underlying `initialData`, so subfields that are not mentioned in the override fall through to the external value:
+
+```typescript
+const form = useForm({
+  initialData: { user: { name: 'A', email: 'x@x' } },
+})
+
+form.getField('user').setInitialData({ name: 'B' })
+
+form.getField('user.name').initialValue.value  // 'B'      (from override)
+form.getField('user.email').initialValue.value // 'x@x'    (from external)
+form.getField('user.name').dirty.value         // false
+```
+
+Pass `{ replace: true }` as the second argument to replace the subtree wholesale instead of merging — keys missing from the override resolve to `undefined`:
+
+```typescript
+form.getField('user').setInitialData({ name: 'B' }, { replace: true })
+
+form.getField('user.email').initialValue.value // undefined
+```
+
+### Interaction with external `initialData` and other overrides
+- **External reassignment wipes overrides.** When the `initialData` ref passed to `useForm` is reassigned, all overrides applied via `setInitialData` are dropped — the form's baseline goes back to the external source.
+- **Cascade on ancestor write.** Calling `setInitialData` on a path drops any existing override on that path *or below* before applying the new one (e.g. setting an override on `user` clears a prior override on `user.name`).
+- **`form.reset()` keeps overrides.** Reset rebuilds `data` from the merged tree (external `initialData` + active overrides), so a `setInitialData` call is treated as the new programmatic baseline.
+
 ## Method `defineValidator`
 The `defineValidator` method allows subcomponents to add validation rules to a form without needing access to the initial `useForm` call. The validator is automatically removed when the component unmounts.
 

--- a/packages/vue-forms/docs/reference.md
+++ b/packages/vue-forms/docs/reference.md
@@ -247,6 +247,21 @@ hobbies.remove(hobbies.items.value[0].id)
 </div>
 ```
 
+### `pushPristine` — add a new item without dirtying its subfields
+`pushPristine(item)` works like `push`, but additionally anchors the new index's subtree as its own baseline (a `setInitialData(item, { scope: 'subtree' })` on the new index path). The new item's subfields start non-dirty, while the array field itself stays dirty — its baseline still reflects the external `initialData`, so navigation guards / dirty checks still warn that something was added.
+
+```typescript
+const rows = form.getFieldArray('rows')
+
+rows.pushPristine({ name: '', email: '' })
+
+form.getField('rows.1.name').dirty.value // false (reads the subtree anchor)
+rows.field.dirty.value                   // true  (a new row exists)
+form.isDirty.value                       // true
+```
+
+Use `push` when the new item is a user edit you want flagged everywhere; use `pushPristine` when it's a blank/placeholder row whose internal fields shouldn't light up dirty/validation noise until the user actually touches them.
+
 For objects where identity should be based on a property (e.g. `id`) rather than reference equality, provide a `hashFn`:
 ```typescript
 const products = form.getFieldArray('products', {

--- a/packages/vue-forms/docs/reference.md
+++ b/packages/vue-forms/docs/reference.md
@@ -153,6 +153,28 @@ form.getField('user').setInitialData({ name: 'B' }, { replace: true })
 form.getField('user.email').initialValue.value // undefined
 ```
 
+### Scoping the override: `tree` (default) vs `subtree`
+`setInitialData` accepts a `scope` option that controls who sees the new baseline:
+
+- **`scope: 'tree'` (default)** — the override becomes part of the global baseline. Both the targeted path *and its ancestors* read it, so the form goes back to non-dirty if `data` matches. Use this when an async load gives you a value that should be treated as if it had been the original initial all along.
+- **`scope: 'subtree'`** — the override anchors the baseline only for the targeted path and its descendants. Strict ancestors keep reading the external `initialData`, so they stay dirty when the change altered the tree shape (e.g. a new array item). Use this when something was added that the user should still be warned about losing on navigation, but whose internal fields shouldn't be marked dirty from the get-go.
+
+```typescript
+const form = useForm({
+  initialData: { rows: [{ name: 'A' }] as { name: string }[] },
+})
+
+// Push a new row (array structure changes → form is dirty)
+form.data.value.rows.push({ name: 'new' })
+
+// Anchor the new row's subtree as its own baseline.
+form.getField('rows.1').setInitialData({ name: 'new' }, { scope: 'subtree' })
+
+form.getField('rows.1.name').dirty.value // false (reads the anchor)
+form.getField('rows').dirty.value         // true  (array baseline unchanged)
+form.isDirty.value                        // true
+```
+
 ### Interaction with external `initialData` and other overrides
 - **External reassignment wipes overrides.** When the `initialData` ref passed to `useForm` is reassigned, all overrides applied via `setInitialData` are dropped — the form's baseline goes back to the external source.
 - **Cascade on ancestor write.** Calling `setInitialData` on a path drops any existing override on that path *or below* before applying the new one (e.g. setting an override on `user` clears a prior override on `user.name`).

--- a/packages/vue-forms/package.json
+++ b/packages/vue-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamnovu/kit-vue-forms",
-  "version": "0.2.18",
+  "version": "0.3.0",
   "description": "",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/vue-forms/src/composables/useField.ts
+++ b/packages/vue-forms/src/composables/useField.ts
@@ -64,6 +64,8 @@ export function useField<T, K extends string>(fieldOptions: UseFieldOptions<T, K
     state.errors = []
   }
 
+  // This method is replaced by the registry and should never be called directly.
+  // This only acts as a stub.
   const setInitialData = (newData: T, _options?: { replace?: boolean }): void => {
     if (!dirty.value) {
       setData(cloneRefValue(newData))

--- a/packages/vue-forms/src/composables/useField.ts
+++ b/packages/vue-forms/src/composables/useField.ts
@@ -37,7 +37,7 @@ export function useField<T, K extends string>(fieldOptions: UseFieldOptions<T, K
   }, { deep: true })
 
   const dirty = computed(() => {
-    return JSON.stringify(state.value) !== JSON.stringify(state.initialValue)
+    return JSON.stringify(state.value) !== JSON.stringify(cloneRefValue(state.initialValue as T))
   })
 
   const setData = (newData: T): void => {

--- a/packages/vue-forms/src/composables/useField.ts
+++ b/packages/vue-forms/src/composables/useField.ts
@@ -1,5 +1,5 @@
 import type { Awaitable } from '@vueuse/core'
-import { computed, reactive, shallowRef, toRefs, unref, watch, type MaybeRef, type MaybeRefOrGetter, type Ref } from 'vue'
+import { computed, reactive, toRefs, unref, watch, type MaybeRef, type MaybeRefOrGetter, type Ref } from 'vue'
 import type { FormField } from '../types/form'
 import type { ValidationErrorMessage, ValidationErrors } from '../types/validation'
 import { cloneRefValue } from '../utils/general'
@@ -24,26 +24,13 @@ export function useField<T, K extends string>(fieldOptions: UseFieldOptions<T, K
     ...defaultOptions,
     ...fieldOptions,
   }
-  const initialValue = shallowRef(Object.freeze(cloneRefValue(options.initialValue))) as Ref<Readonly<T | undefined>>
-
   const state = reactive({
     value: options.value,
     path: options.path,
-    initialValue,
+    initialValue: options.initialValue,
     errors: options.errors,
     touched: false,
   })
-
-  watch(
-    shallowRef(options.initialValue),
-    () => {
-      initialValue.value = Object.freeze(cloneRefValue(options.initialValue))
-      if (state.value !== unref(options.initialValue)) {
-        state.value = cloneRefValue(options.initialValue)
-      }
-    },
-    { flush: 'sync' },
-  )
 
   watch(() => state.value, (newData) => {
     fieldOptions.onChange?.(newData as T)
@@ -71,17 +58,19 @@ export function useField<T, K extends string>(fieldOptions: UseFieldOptions<T, K
   const reset = (): void => {
     const lastPathPart = state.path.split('.').at(-1) || ''
     if (unref(options.existsInForm) && !/^\d+$/.test(lastPathPart)) {
-      state.value = cloneRefValue(state.initialValue)
+      state.value = cloneRefValue(state.initialValue as T)
     }
     state.touched = false
     state.errors = []
   }
 
-  const setInitialData = (newData: T): void => {
+  const setInitialData = (newData: T, _options?: { replace?: boolean }): void => {
     if (!dirty.value) {
       setData(cloneRefValue(newData))
     }
-    state.initialValue = newData
+    // Standalone-mode fallback: when no registry has replaced this method, keep
+    // the previous behavior of updating the local baseline directly.
+    state.initialValue = newData as typeof state.initialValue
   }
 
   const setErrors = (newErrors: ValidationErrorMessage[]): void => {

--- a/packages/vue-forms/src/composables/useFieldArray.ts
+++ b/packages/vue-forms/src/composables/useFieldArray.ts
@@ -132,6 +132,21 @@ export function useFieldArray<T extends FormDataDefault, K extends Paths<T>, TOu
     return items.value.at(-1)!
   }
 
+  const pushPristine = (item: Item) => {
+    const current = (arrayField.data.value ?? []) as Item[]
+    const newIndex = current.length
+    arrayField.setData([...current, item] as Items)
+
+    // Anchor the new item's subtree as its own baseline. Subtree scope keeps
+    // the array field (and any further ancestors) dirty against the external
+    // initialData, while the new index and its descendants read the anchor.
+    const newItemPath = `${path}.${newIndex}` as Paths<T>
+    const newItemField = form.getField(newItemPath) as unknown as FormField<Item, string>
+    newItemField.setInitialData(item, { scope: 'subtree' })
+
+    return items.value.at(-1)!
+  }
+
   const remove = (id: Id) => {
     const currentData = (arrayField.data.value ?? []) as Item[]
     const currentItem = items.value.findIndex(
@@ -165,6 +180,7 @@ export function useFieldArray<T extends FormDataDefault, K extends Paths<T>, TOu
   return {
     items,
     push,
+    pushPristine,
     remove,
     insert,
     field: arrayField,

--- a/packages/vue-forms/src/composables/useFieldRegistry.ts
+++ b/packages/vue-forms/src/composables/useFieldRegistry.ts
@@ -12,9 +12,11 @@ import {
 } from 'vue'
 import type { FieldsTuple, FormDataDefault, FormField } from '../types/form'
 import type { Paths, PickProps } from '../types/util'
+import { cloneRefValue } from '../utils/general'
 import { existsPath, getLens, getNestedValue } from '../utils/path'
 import { Rc } from '../utils/rc'
 import { useField, type UseFieldOptions } from './useField'
+import type { InitialDataOverride } from './useInitialDataOverride'
 import type { ValidationState } from './useValidation'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -57,14 +59,15 @@ const optionDefaults = {
 // A computed that always reflects the latest value from the getter
 // This computed forces updates even if the value is the same (to trigger watchers)
 function initialDataSync<T extends FormDataDefault>(
-  formState: FormState<T>,
+  initialDataOverride: InitialDataOverride<T>,
   path: Paths<T>,
 ) {
-  const getNewValue = () => getNestedValue(formState.initialData, path)
+  const getNewValue = () =>
+    getNestedValue(initialDataOverride.effectiveInitialData.value, path)
   const initialValueRef = shallowRef(getNewValue())
 
   watch(
-    () => formState.initialData,
+    initialDataOverride.effectiveInitialData,
     () => {
       initialValueRef.value = getNewValue()
       triggerRef(initialValueRef)
@@ -78,6 +81,7 @@ function initialDataSync<T extends FormDataDefault>(
 export function useFieldRegistry<T extends FormDataDefault, TOut = T>(
   formState: FormState<T>,
   validationState: ValidationState<T, TOut>,
+  initialDataOverride: InitialDataOverride<T>,
   fieldRegistryOptions?: FieldRegistryOptions,
 ) {
   const fieldReferenceCounter = new Map<Paths<T>, Rc>()
@@ -124,7 +128,7 @@ export function useFieldRegistry<T extends FormDataDefault, TOut = T>(
       const field = useField({
         path,
         value: getLens(toRef(formState, 'data'), path),
-        initialValue: initialDataSync(formState, path),
+        initialValue: initialDataSync(initialDataOverride, path),
         existsInForm: computed(() => existsPath(formState.data, unref(path))),
         errors: computed({
           get() {
@@ -153,6 +157,22 @@ export function useFieldRegistry<T extends FormDataDefault, TOut = T>(
           ])
         },
       })
+
+      // Replace setInitialData with a registry-provided version that writes to
+      // the override layer so subfields resolve their baseline from the merged
+      // tree.
+      field.setInitialData = (
+        newData: PickProps<T, K>,
+        setOptions?: { replace?: boolean },
+      ) => {
+        // Capture dirty state before the override write, since writing to the
+        // override layer synchronously updates this field's initialValue.
+        const wasDirty = field.dirty.value
+        initialDataOverride.set(path, newData, setOptions)
+        if (!wasDirty) {
+          field.setData(cloneRefValue(newData))
+        }
+      }
 
       registerField(field)
     }

--- a/packages/vue-forms/src/composables/useFieldRegistry.ts
+++ b/packages/vue-forms/src/composables/useFieldRegistry.ts
@@ -13,10 +13,13 @@ import {
 import type { FieldsTuple, FormDataDefault, FormField } from '../types/form'
 import type { Paths, PickProps } from '../types/util'
 import { cloneRefValue } from '../utils/general'
-import { existsPath, getLens, getNestedValue } from '../utils/path'
+import { existsPath, getLens } from '../utils/path'
 import { Rc } from '../utils/rc'
 import { useField, type UseFieldOptions } from './useField'
-import type { InitialDataOverride } from './useInitialDataOverride'
+import type {
+  InitialDataOverride,
+  InitialDataOverrideSetOptions,
+} from './useInitialDataOverride'
 import type { ValidationState } from './useValidation'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -58,18 +61,18 @@ const optionDefaults = {
 
 // A computed that always reflects the latest value from the getter
 // This computed forces updates even if the value is the same (to trigger watchers)
-function initialDataSync<T extends FormDataDefault>(
+function initialDataSync<T extends FormDataDefault, K extends Paths<T>>(
   initialDataOverride: InitialDataOverride<T>,
-  path: Paths<T>,
+  path: K,
 ) {
-  const getNewValue = () =>
-    getNestedValue(initialDataOverride.effectiveInitialData.value, path)
-  const initialValueRef = shallowRef(getNewValue())
+  type FieldValue = PickProps<T, K>
+  const getNewValue = () => initialDataOverride.resolveAt(path) as FieldValue
+  const initialValueRef = shallowRef<FieldValue>(getNewValue())
 
   watch(
-    initialDataOverride.effectiveInitialData,
-    () => {
-      initialValueRef.value = getNewValue()
+    () => initialDataOverride.resolveAt(path),
+    (newValue) => {
+      initialValueRef.value = newValue as FieldValue
       triggerRef(initialValueRef)
     },
     { flush: 'sync' },
@@ -163,7 +166,7 @@ export function useFieldRegistry<T extends FormDataDefault, TOut = T>(
       // tree.
       field.setInitialData = (
         newData: PickProps<T, K>,
-        setOptions?: { replace?: boolean },
+        setOptions?: InitialDataOverrideSetOptions,
       ) => {
         // Capture dirty state before the override write, since writing to the
         // override layer synchronously updates this field's initialValue.

--- a/packages/vue-forms/src/composables/useForm.ts
+++ b/packages/vue-forms/src/composables/useForm.ts
@@ -15,6 +15,7 @@ import { makeSubmitHandler } from '../utils/submitHandler'
 import { useFieldArray } from './useFieldArray'
 import { useFieldRegistry } from './useFieldRegistry'
 import { useFormState } from './useFormState'
+import { useInitialDataOverride } from './useInitialDataOverride'
 import { createSubformInterface } from './useSubform'
 import {
   useValidation,
@@ -60,6 +61,7 @@ export function useForm<T extends FormDataDefault, TOut = T>(
 
   /* eslint-enable no-redeclare */
   const initialData = computed(() => cloneRefValue(options.initialData))
+  const initialDataOverride = useInitialDataOverride(initialData)
 
   const data = ref<T>(cloneRefValue(initialData)) as Ref<T>
 
@@ -77,7 +79,7 @@ export function useForm<T extends FormDataDefault, TOut = T>(
   )
 
   const validationState = useValidation(state, options)
-  const fieldRegistry = useFieldRegistry(state, validationState, {
+  const fieldRegistry = useFieldRegistry(state, validationState, initialDataOverride, {
     keepValuesOnUnmount: options.keepValuesOnUnmount,
     onBlur: async (path: string) => {
       validationState.validateStrategy('validateOnBlur', path)
@@ -92,7 +94,7 @@ export function useForm<T extends FormDataDefault, TOut = T>(
   const formState = useFormState(fieldRegistry)
 
   const reset = () => {
-    data.value = cloneRefValue(initialData)
+    data.value = cloneRefValue(initialDataOverride.effectiveInitialData)
     validationState.reset()
     for (const field of fieldRegistry.fields.value) {
       field.reset()

--- a/packages/vue-forms/src/composables/useInitialDataOverride.ts
+++ b/packages/vue-forms/src/composables/useInitialDataOverride.ts
@@ -1,0 +1,76 @@
+import { merge } from 'lodash-es'
+import {
+  computed,
+  shallowReactive,
+  watch,
+  type ComputedRef,
+  type Ref,
+} from 'vue'
+import type { FormDataDefault } from '../types/form'
+import type { Paths, PickProps } from '../types/util'
+import { cloneRefValue } from '../utils/general'
+import {
+  dropOverridesAtAndBelow,
+  getNestedValue,
+  setNestedValue,
+} from '../utils/path'
+
+export interface InitialDataOverride<T extends FormDataDefault> {
+  effectiveInitialData: ComputedRef<T>
+  set: (path: string, value: unknown, options?: { replace?: boolean }) => void
+}
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  v !== null && typeof v === 'object' && !Array.isArray(v)
+
+export function useInitialDataOverride<T extends FormDataDefault>(
+  initialData: Ref<T> | ComputedRef<T>,
+): InitialDataOverride<T> {
+  const overrides = shallowReactive(
+    new Map<string, { value: unknown; replace: boolean }>(),
+  )
+
+  const effectiveInitialData = computed<T>(() => {
+    const result = cloneRefValue(initialData)
+
+    const sortedEntries = [...overrides.entries()].sort(
+      ([a], [b]) => a.split('.').length - b.split('.').length,
+    )
+
+    for (const [path, entry] of sortedEntries) {
+      const typedPath = path as Paths<T>
+      const existing = getNestedValue<T, Paths<T>>(result, typedPath)
+
+      const nextValue
+        = entry.replace || !isPlainObject(entry.value) || !isPlainObject(existing)
+          ? entry.value
+          : merge({}, existing, entry.value)
+
+      setNestedValue<T, Paths<T>>(
+        result,
+        typedPath,
+        nextValue as PickProps<T, Paths<T>>,
+      )
+    }
+
+    return result
+  })
+
+  // External initialData reassignment wipes all overrides. Programmatic
+  // overrides via setInitialData stay scoped to their own subtrees.
+  watch(
+    initialData,
+    () => {
+      overrides.clear()
+    },
+    { flush: 'sync' },
+  )
+
+  return {
+    effectiveInitialData,
+    set(path, value, options) {
+      dropOverridesAtAndBelow(overrides, path)
+      overrides.set(path, { value, replace: options?.replace ?? false })
+    },
+  }
+}

--- a/packages/vue-forms/src/composables/useInitialDataOverride.ts
+++ b/packages/vue-forms/src/composables/useInitialDataOverride.ts
@@ -15,36 +15,71 @@ import {
   setNestedValue,
 } from '../utils/path'
 
+export type InitialDataOverrideScope = 'tree' | 'subtree'
+
+export interface InitialDataOverrideSetOptions {
+  replace?: boolean
+  scope?: InitialDataOverrideScope
+}
+
 export interface InitialDataOverride<T extends FormDataDefault> {
+  // Full merge of external initialData with all overrides regardless of scope.
+  // Used by form.reset() to rebuild the data tree.
   effectiveInitialData: ComputedRef<T>
-  set: (path: string, value: unknown, options?: { replace?: boolean }) => void
+  // Per-field baseline resolution. Honors scope: subtree-scoped overrides at
+  // paths strictly below `path` are invisible to that read, so ancestors keep
+  // their external baseline and stay dirty when descendants extend the tree.
+  resolveAt: (path: string) => unknown
+  set: (
+    path: string,
+    value: unknown,
+    options?: InitialDataOverrideSetOptions,
+  ) => void
+}
+
+interface OverrideEntry {
+  value: unknown
+  replace: boolean
+  scope: InitialDataOverrideScope
 }
 
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>
   v !== null && typeof v === 'object' && !Array.isArray(v)
 
+const isStrictDescendant = (candidate: string, ancestor: string): boolean => {
+  if (ancestor === '') return candidate !== ''
+  return candidate.startsWith(ancestor + '.')
+}
+
 export function useInitialDataOverride<T extends FormDataDefault>(
   initialData: Ref<T> | ComputedRef<T>,
 ): InitialDataOverride<T> {
-  const overrides = shallowReactive(
-    new Map<string, { value: unknown; replace: boolean }>(),
-  )
+  const overrides = shallowReactive(new Map<string, OverrideEntry>())
 
-  const effectiveInitialData = computed<T>(() => {
+  const buildTree = (readingPath?: string): T => {
     const result = cloneRefValue(initialData)
-
     const sortedEntries = [...overrides.entries()].sort(
       ([a], [b]) => a.split('.').length - b.split('.').length,
     )
 
     for (const [path, entry] of sortedEntries) {
+      // For a per-field read, skip subtree-scoped overrides that live strictly
+      // below the reading path — those anchors must remain invisible to
+      // ancestors of their own subtree.
+      if (
+        readingPath !== undefined
+        && entry.scope === 'subtree'
+        && isStrictDescendant(path, readingPath)
+      ) {
+        continue
+      }
+
       const typedPath = path as Paths<T>
       const existing = getNestedValue<T, Paths<T>>(result, typedPath)
 
-      const nextValue
-        = entry.replace || !isPlainObject(entry.value) || !isPlainObject(existing)
-          ? entry.value
-          : merge({}, existing, entry.value)
+      const nextValue = entry.replace || !isPlainObject(entry.value) || !isPlainObject(existing)
+        ? entry.value
+        : merge({}, existing, entry.value)
 
       setNestedValue<T, Paths<T>>(
         result,
@@ -54,7 +89,15 @@ export function useInitialDataOverride<T extends FormDataDefault>(
     }
 
     return result
-  })
+  }
+
+  const effectiveInitialData = computed<T>(() => buildTree())
+
+  const resolveAt = (path: string): unknown => {
+    const tree = buildTree(path)
+    if (path === '') return tree
+    return getNestedValue<T, Paths<T>>(tree, path as Paths<T>)
+  }
 
   // External initialData reassignment wipes all overrides. Programmatic
   // overrides via setInitialData stay scoped to their own subtrees.
@@ -68,9 +111,14 @@ export function useInitialDataOverride<T extends FormDataDefault>(
 
   return {
     effectiveInitialData,
+    resolveAt,
     set(path, value, options) {
       dropOverridesAtAndBelow(overrides, path)
-      overrides.set(path, { value, replace: options?.replace ?? false })
+      overrides.set(path, {
+        value,
+        replace: options?.replace ?? false,
+        scope: options?.scope ?? 'tree',
+      })
     },
   }
 }

--- a/packages/vue-forms/src/composables/useInitialDataOverride.ts
+++ b/packages/vue-forms/src/composables/useInitialDataOverride.ts
@@ -43,8 +43,14 @@ interface OverrideEntry {
   scope: InitialDataOverrideScope
 }
 
-const isPlainObject = (v: unknown): v is Record<string, unknown> =>
-  v !== null && typeof v === 'object' && !Array.isArray(v)
+const isPlainObject = (v: unknown): v is Record<string, unknown> => {
+  if (v === null || typeof v !== 'object') return false
+  const proto = Object.getPrototypeOf(v)
+  // Only treat literal `{}` / `Object.create(null)` as mergeable. Class
+  // instances, Date, Map, Set, RegExp, etc. have no enumerable own props for
+  // lodash.merge to copy and would silently collapse to `{}`.
+  return proto === Object.prototype || proto === null
+}
 
 const isStrictDescendant = (candidate: string, ancestor: string): boolean => {
   if (ancestor === '') return candidate !== ''

--- a/packages/vue-forms/src/types/form.ts
+++ b/packages/vue-forms/src/types/form.ts
@@ -45,8 +45,9 @@ export interface FormField<T, P extends string> {
   /**
    * Sets the initial data for the field. If the field is not dirty, it also updates the current data.
    * @param newData - The new initial data to set.
+   * @param options - Optional. Pass `{ replace: true }` to replace the subtree entirely instead of deep-merging.
    */
-  setInitialData: (newData: T) => void
+  setInitialData: (newData: T, options?: { replace?: boolean }) => void
   onBlur: () => void
   onFocus: () => void
   reset: () => void

--- a/packages/vue-forms/src/types/form.ts
+++ b/packages/vue-forms/src/types/form.ts
@@ -29,6 +29,13 @@ export interface FieldItem<Item, Path extends string> {
 export interface FieldArray<Item, Path extends string> {
   items: ShallowRef<FieldItem<Item, Path>[]>
   push: (item: Item) => FieldItem<Item, Path>
+  /**
+   * Pushes a new item and anchors its subtree as the baseline for that index
+   * (subtree-scoped `setInitialData`). The new item's subfields are clean from
+   * the moment they're registered, while the array field itself stays dirty
+   * because its baseline still reflects the external `initialData`.
+   */
+  pushPristine: (item: Item) => FieldItem<Item, Path>
   remove: (id: string) => void
   insert: (item: Item, index: number) => FieldItem<Item, Path>
   field: FormField<Item[], Path>

--- a/packages/vue-forms/src/types/form.ts
+++ b/packages/vue-forms/src/types/form.ts
@@ -46,8 +46,17 @@ export interface FormField<T, P extends string> {
    * Sets the initial data for the field. If the field is not dirty, it also updates the current data.
    * @param newData - The new initial data to set.
    * @param options - Optional. Pass `{ replace: true }` to replace the subtree entirely instead of deep-merging.
+   *   Pass `{ scope: 'subtree' }` to anchor the baseline only for this field and its descendants — ancestors
+   *   continue to read from the external initialData and stay dirty if the override changed the tree shape.
+   *   Defaults to `{ scope: 'tree' }`, which makes the override visible to ancestors as well.
    */
-  setInitialData: (newData: T, options?: { replace?: boolean }) => void
+  setInitialData: (
+    newData: T,
+    options?: {
+      replace?: boolean
+      scope?: 'tree' | 'subtree'
+    },
+  ) => void
   onBlur: () => void
   onFocus: () => void
   reset: () => void

--- a/packages/vue-forms/src/utils/path.ts
+++ b/packages/vue-forms/src/utils/path.ts
@@ -108,7 +108,7 @@ export function dropOverridesAtAndBelow(
   path: string,
 ): void {
   for (const key of [...overrides.keys()]) {
-    if (key === path || key.startsWith(path + '.')) {
+    if (key === path || path === '' || key.startsWith(path + '.')) {
       overrides.delete(key)
     }
   }

--- a/packages/vue-forms/src/utils/path.ts
+++ b/packages/vue-forms/src/utils/path.ts
@@ -103,6 +103,17 @@ export function joinPath<Base extends string, Sub extends string>(
   return `${basePath}.${subPath}` as JoinPath<Base, Sub>
 }
 
+export function dropOverridesAtAndBelow(
+  overrides: Map<string, unknown>,
+  path: string,
+): void {
+  for (const key of [...overrides.keys()]) {
+    if (key === path || key.startsWith(path + '.')) {
+      overrides.delete(key)
+    }
+  }
+}
+
 export function filterErrorsForPath(errors: ErrorBag, path: string): ErrorBag {
   // Handle empty path - return all errors
   if (!path) {

--- a/packages/vue-forms/tests/formState.test.ts
+++ b/packages/vue-forms/tests/formState.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { reactive } from 'vue'
+import { reactive, toRef } from 'vue'
 import { useFieldRegistry } from '../src/composables/useFieldRegistry'
 import { useFormState } from '../src/composables/useFormState'
 import { useForm } from '../src'
+import { useInitialDataOverride } from '../src/composables/useInitialDataOverride'
 import { useValidation } from '../src/composables/useValidation'
 
 describe('useFormState', () => {
@@ -51,7 +52,8 @@ describe('useFormState', () => {
       initialData,
     })
     const validationState = useValidation(state, {})
-    const fields = useFieldRegistry(state, validationState)
+    const initialDataOverride = useInitialDataOverride(toRef(state, 'initialData'))
+    const fields = useFieldRegistry(state, validationState, initialDataOverride)
 
     const nameField = fields.defineField({ path: 'name' })
     fields.defineField({ path: 'email' })
@@ -74,7 +76,8 @@ describe('useFormState', () => {
       initialData,
     })
     const validationState = useValidation(state, {})
-    const fields = useFieldRegistry(state, validationState)
+    const initialDataOverride = useInitialDataOverride(toRef(state, 'initialData'))
+    const fields = useFieldRegistry(state, validationState, initialDataOverride)
 
     const formState = useFormState(fields)
 

--- a/packages/vue-forms/tests/initialDataOverride.test.ts
+++ b/packages/vue-forms/tests/initialDataOverride.test.ts
@@ -429,6 +429,26 @@ describe('initialData overrides — subfield propagation', () => {
     expect(nameField.initialValue.value).toBe('B')
   })
 
+  it('overriding a Date replaces it wholesale instead of merging to {}', () => {
+    const initial = new Date('2020-01-01T00:00:00Z')
+    const next = new Date('2026-05-19T00:00:00Z')
+
+    const form = useForm({
+      initialData: { createdAt: initial },
+    })
+
+    const field = form.getField('createdAt')
+    field.setInitialData(next)
+
+    // Without the plain-object guard, merge({}, initial, next) would yield {}
+    // because Date has no enumerable own properties. With the guard, the
+    // override replaces wholesale.
+    expect(field.initialValue.value).toBeInstanceOf(Date)
+    expect((field.initialValue.value as Date).toISOString()).toBe(
+      next.toISOString(),
+    )
+  })
+
   it('form.reset() rebuilds data from the merged tree (overrides survive)', () => {
     const form = useForm({
       initialData: {

--- a/packages/vue-forms/tests/initialDataOverride.test.ts
+++ b/packages/vue-forms/tests/initialDataOverride.test.ts
@@ -207,6 +207,228 @@ describe('initialData overrides — subfield propagation', () => {
     expect(nameField.dirty.value).toBe(true)
   })
 
+  it('subtree scope: strict ancestor reads external baseline, override path and below read override', () => {
+    const form = useForm({
+      initialData: {
+        outer: {
+          inner: {
+            name: 'A',
+            email: 'x@x',
+          },
+        },
+      },
+    })
+
+    const outerField = form.getField('outer')
+    const innerField = form.getField('outer.inner')
+    const nameField = form.getField('outer.inner.name')
+
+    innerField.setInitialData(
+      {
+        name: 'B',
+        email: 'x@x',
+      },
+      { scope: 'subtree' },
+    )
+
+    // Override path and descendants see the override.
+    expect(innerField.initialValue.value).toEqual({
+      name: 'B',
+      email: 'x@x',
+    })
+    expect(nameField.initialValue.value).toBe('B')
+    expect(nameField.dirty.value).toBe(false)
+
+    // Strict ancestor (outer) keeps the external baseline. Data was pushed
+    // into the inner subtree (the inner field was clean), so outer.data now
+    // diverges from outer's external initial → dirty.
+    expect(outerField.initialValue.value).toEqual({
+      inner: {
+        name: 'A',
+        email: 'x@x',
+      },
+    })
+    expect(outerField.dirty.value).toBe(true)
+    expect(form.isDirty.value).toBe(true)
+  })
+
+  it('subtree scope on array index: array stays dirty, item subfields clean', () => {
+    type Row = {
+      name: string
+      email: string
+    }
+    const form = useForm<{ rows: Row[] }>({
+      initialData: {
+        rows: [
+          {
+            name: 'A',
+            email: 'a@a',
+          },
+        ],
+      },
+    })
+
+    const arrayField = form.getField('rows')
+    form.getField('rows.0.name')
+    form.getField('rows.0.email')
+
+    // Mimic a "push pristine" flow: push a new item, then anchor it.
+    const newItem: Row = {
+      name: 'B',
+      email: 'b@b',
+    }
+    form.data.value.rows.push(newItem)
+
+    // Register the new index's subfields so we can inspect them.
+    const newName = form.getField('rows.1.name')
+    const newEmail = form.getField('rows.1.email')
+    const newRow = form.getField('rows.1')
+
+    expect(arrayField.dirty.value).toBe(true) // length changed
+
+    newRow.setInitialData(newItem, { scope: 'subtree' })
+
+    // The whole new row's subtree reads from the anchor → all clean.
+    expect(newName.initialValue.value).toBe('B')
+    expect(newEmail.initialValue.value).toBe('b@b')
+    expect(newName.dirty.value).toBe(false)
+    expect(newEmail.dirty.value).toBe(false)
+    expect(newRow.dirty.value).toBe(false)
+
+    // The array field stays dirty: its baseline still has only the original
+    // item (subtree override at rows.1 is invisible to rows).
+    expect(arrayField.initialValue.value).toEqual([
+      {
+        name: 'A',
+        email: 'a@a',
+      },
+    ])
+    expect(arrayField.dirty.value).toBe(true)
+    expect(form.isDirty.value).toBe(true)
+  })
+
+  it('subtree scope does not affect sibling subtrees', () => {
+    type Data = {
+      a: { v: string }
+      b: { v: string }
+    }
+    const form = useForm<Data>({
+      initialData: {
+        a: { v: 'a' },
+        b: { v: 'b' },
+      },
+    })
+
+    const aField = form.getField('a')
+    const bField = form.getField('b')
+
+    aField.setInitialData({ v: 'A' }, { scope: 'subtree' })
+
+    expect(form.getField('a.v').initialValue.value).toBe('A')
+    expect(bField.initialValue.value).toEqual({ v: 'b' })
+    expect(bField.dirty.value).toBe(false)
+  })
+
+  it('subtree scope: setInitialData on the same field is the natural read path', () => {
+    // The field whose path equals the override path *does* read the override
+    // (the rule is "skip subtree overrides strictly below the reading path").
+    const form = useForm({
+      initialData: { user: { name: 'A' } },
+    })
+
+    const userField = form.getField('user')
+    userField.setInitialData({ name: 'B' }, { scope: 'subtree' })
+
+    expect(userField.initialValue.value).toEqual({ name: 'B' })
+    expect(userField.dirty.value).toBe(false)
+  })
+
+  it('mixed scopes: tree override at parent + subtree override at child', () => {
+    const form = useForm({
+      initialData: {
+        user: {
+          profile: {
+            name: 'A',
+            age: 1,
+          },
+          settings: { theme: 'light' },
+        },
+      },
+    })
+
+    const userField = form.getField('user')
+    const profileField = form.getField('user.profile')
+    const nameField = form.getField('user.profile.name')
+
+    // Tree override at user: globally repoints baseline.
+    userField.setInitialData(
+      {
+        profile: {
+          name: 'B',
+          age: 2,
+        },
+        settings: { theme: 'dark' },
+      },
+      { scope: 'tree' },
+    )
+    expect(userField.dirty.value).toBe(false)
+    expect(profileField.initialValue.value).toEqual({
+      name: 'B',
+      age: 2,
+    })
+
+    // Subtree override deeper: should pin only its subtree, but since it lives
+    // strictly below the user-tree override, user's view is unaffected.
+    nameField.setInitialData('C', { scope: 'subtree' })
+
+    // The leaf reads its own anchor.
+    expect(nameField.initialValue.value).toBe('C')
+    expect(nameField.dirty.value).toBe(false)
+
+    // The profile field (ancestor of the subtree anchor, descendant of the
+    // tree override) keeps its tree-override view: name still 'B'.
+    expect(profileField.initialValue.value).toEqual({
+      name: 'B',
+      age: 2,
+    })
+
+    // The user field (further ancestor) still sees its tree override too.
+    expect(userField.initialValue.value).toEqual({
+      profile: {
+        name: 'B',
+        age: 2,
+      },
+      settings: { theme: 'dark' },
+    })
+  })
+
+  it('subtree scope: external initialData reassignment still wipes it', () => {
+    const initialData = ref({ user: { name: 'A' } })
+    const form = useForm({ initialData })
+
+    const userField = form.getField('user')
+    userField.setInitialData({ name: 'B' }, { scope: 'subtree' })
+    expect(userField.initialValue.value).toEqual({ name: 'B' })
+
+    initialData.value = { user: { name: 'Z' } }
+    expect(userField.initialValue.value).toEqual({ name: 'Z' })
+  })
+
+  it('subtree scope: cascade drops a deeper subtree anchor when ancestor is rewritten', () => {
+    const form = useForm({
+      initialData: { user: { name: 'A' } },
+    })
+
+    const userField = form.getField('user')
+    const nameField = form.getField('user.name')
+
+    nameField.setInitialData('X', { scope: 'subtree' })
+    expect(nameField.initialValue.value).toBe('X')
+
+    userField.setInitialData({ name: 'B' }, { scope: 'subtree' })
+    expect(nameField.initialValue.value).toBe('B')
+  })
+
   it('form.reset() rebuilds data from the merged tree (overrides survive)', () => {
     const form = useForm({
       initialData: {

--- a/packages/vue-forms/tests/initialDataOverride.test.ts
+++ b/packages/vue-forms/tests/initialDataOverride.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { useForm } from '../src/composables/useForm'
+
+describe('initialData overrides — subfield propagation', () => {
+  it('default merge: subfields see ancestor override and stay clean', () => {
+    const form = useForm({
+      initialData: {
+        user: {
+          name: 'A',
+          email: 'x@x',
+        },
+      },
+    })
+
+    const userField = form.getField('user')
+    const nameField = form.getField('user.name')
+    const emailField = form.getField('user.email')
+
+    userField.setInitialData({
+      name: 'B',
+      email: 'x@x',
+    })
+
+    expect(nameField.initialValue.value).toBe('B')
+    expect(nameField.dirty.value).toBe(false)
+
+    // email was not touched by the override → falls through to external
+    expect(emailField.initialValue.value).toBe('x@x')
+    expect(emailField.dirty.value).toBe(false)
+  })
+
+  it('partial merge at parent path leaves untouched siblings on external value', () => {
+    const form = useForm({
+      initialData: {
+        user: {
+          name: 'A',
+          email: 'x@x',
+        },
+      },
+    })
+
+    const userField = form.getField('user')
+    const emailField = form.getField('user.email')
+
+    // Override only `name` — `email` should fall through to the external value
+    userField.setInitialData({ name: 'B' } as {
+      name: string
+      email: string
+    })
+
+    expect(form.getField('user.name').initialValue.value).toBe('B')
+    expect(emailField.initialValue.value).toBe('x@x')
+  })
+
+  it('replace flag drops sibling keys at the overridden path', () => {
+    const form = useForm({
+      initialData: {
+        user: {
+          name: 'A',
+          email: 'x@x',
+        },
+      },
+    })
+
+    const userField = form.getField('user')
+    const emailField = form.getField('user.email')
+
+    userField.setInitialData(
+      { name: 'B' } as {
+        name: string
+        email: string
+      },
+      { replace: true },
+    )
+
+    expect(form.getField('user.name').initialValue.value).toBe('B')
+    expect(emailField.initialValue.value).toBeUndefined()
+  })
+
+  it('external initialData reassignment wipes overrides', () => {
+    const initialData = ref({
+      user: {
+        name: 'A',
+        email: 'x@x',
+      },
+    })
+
+    const form = useForm({ initialData })
+    const userField = form.getField('user')
+    const nameField = form.getField('user.name')
+
+    userField.setInitialData({
+      name: 'B',
+      email: 'x@x',
+    })
+    expect(nameField.initialValue.value).toBe('B')
+
+    initialData.value = {
+      user: {
+        name: 'C',
+        email: 'y@y',
+      },
+    }
+
+    expect(nameField.initialValue.value).toBe('C')
+    expect(form.getField('user.email').initialValue.value).toBe('y@y')
+  })
+
+  it('overriding an ancestor drops a descendant override (cascade)', () => {
+    const form = useForm({
+      initialData: {
+        user: {
+          name: 'A',
+          email: 'x@x',
+        },
+      },
+    })
+
+    const userField = form.getField('user')
+    const nameField = form.getField('user.name')
+
+    nameField.setInitialData('X')
+    expect(nameField.initialValue.value).toBe('X')
+
+    // Writing to the ancestor invalidates the descendant override
+    userField.setInitialData({
+      name: 'B',
+      email: 'x@x',
+    })
+    expect(nameField.initialValue.value).toBe('B')
+  })
+
+  it('sibling-prefix paths are not dropped by cascade', () => {
+    type Data = {
+      users1: { name: string }
+      users10: { name: string }
+    }
+    const form = useForm<Data>({
+      initialData: {
+        users1: { name: 'one' },
+        users10: { name: 'ten' },
+      },
+    })
+
+    const users1Field = form.getField('users1')
+    const users10Field = form.getField('users10')
+
+    users1Field.setInitialData({ name: 'one-override' })
+    expect(form.getField('users1.name').initialValue.value).toBe('one-override')
+
+    // Writing to a sibling whose path is a prefix-collision string must not
+    // touch the existing override on `users1`.
+    users10Field.setInitialData({ name: 'ten-override' })
+
+    expect(form.getField('users1.name').initialValue.value).toBe('one-override')
+    expect(form.getField('users10.name').initialValue.value).toBe('ten-override')
+  })
+
+  it('clean parent override pushes value into subfield data', () => {
+    const form = useForm({
+      initialData: {
+        user: {
+          name: 'A',
+          email: 'x@x',
+        },
+      },
+    })
+
+    const userField = form.getField('user')
+    const nameField = form.getField('user.name')
+
+    userField.setInitialData({
+      name: 'B',
+      email: 'x@x',
+    })
+
+    expect(nameField.data.value).toBe('B')
+    expect(form.isDirty.value).toBe(false)
+  })
+
+  it('dirty subfield keeps its value when an ancestor override is set', () => {
+    const form = useForm({
+      initialData: {
+        user: {
+          name: 'A',
+          email: 'x@x',
+        },
+      },
+    })
+
+    const userField = form.getField('user')
+    const nameField = form.getField('user.name')
+
+    nameField.setData('Z')
+    expect(nameField.dirty.value).toBe(true)
+
+    userField.setInitialData({
+      name: 'B',
+      email: 'x@x',
+    })
+
+    // Field is dirty → data is preserved, but baseline still tracks the
+    // override (so dirty stays true because Z ≠ B).
+    expect(nameField.data.value).toBe('Z')
+    expect(nameField.initialValue.value).toBe('B')
+    expect(nameField.dirty.value).toBe(true)
+  })
+
+  it('form.reset() rebuilds data from the merged tree (overrides survive)', () => {
+    const form = useForm({
+      initialData: {
+        user: {
+          name: 'A',
+          email: 'x@x',
+        },
+      },
+    })
+
+    const userField = form.getField('user')
+    form.getField('user.name')
+    form.getField('user.email')
+
+    userField.setInitialData({ name: 'B' } as {
+      name: string
+      email: string
+    })
+
+    // Mutate the data away from the override, then reset
+    form.data.value.user.name = 'changed'
+    form.reset()
+
+    expect(form.data.value.user.name).toBe('B')
+    expect(form.data.value.user.email).toBe('x@x')
+    expect(form.isDirty.value).toBe(false)
+  })
+})

--- a/packages/vue-forms/tests/useFieldArray.test.ts
+++ b/packages/vue-forms/tests/useFieldArray.test.ts
@@ -350,4 +350,116 @@ describe('useFieldArray', () => {
       expect(fieldArray.items.value[2].item.name).toBe('Third')
     })
   })
+
+  describe('pushPristine', () => {
+    it('adds an item, keeps the array dirty, and marks the new item subfields clean', () => {
+      type Row = {
+        name: string
+        email: string
+      }
+      const form = useForm<{ rows: Row[] }>({
+        initialData: {
+          rows: [
+            {
+              name: 'A',
+              email: 'a@a',
+            },
+          ],
+        },
+      })
+      const fieldArray = useFieldArray(form, 'rows')
+
+      const newItem: Row = {
+        name: 'new',
+        email: 'new@x',
+      }
+      const added = fieldArray.pushPristine(newItem)
+
+      expect(form.data.value.rows).toEqual([
+        {
+          name: 'A',
+          email: 'a@a',
+        },
+        {
+          name: 'new',
+          email: 'new@x',
+        },
+      ])
+      expect(added.path).toBe('rows.1')
+
+      // Subfields of the new index are clean against the subtree anchor.
+      const newName = form.getField('rows.1.name')
+      const newEmail = form.getField('rows.1.email')
+      expect(newName.initialValue.value).toBe('new')
+      expect(newEmail.initialValue.value).toBe('new@x')
+      expect(newName.dirty.value).toBe(false)
+      expect(newEmail.dirty.value).toBe(false)
+
+      // The array field itself stays dirty — the array baseline does not see
+      // the subtree anchor.
+      expect(fieldArray.field.dirty.value).toBe(true)
+      expect(form.isDirty.value).toBe(true)
+    })
+
+    it('subfields registered before pushPristine become clean once the anchor is set', () => {
+      type Row = { name: string }
+      const form = useForm<{ rows: Row[] }>({
+        initialData: { rows: [{ name: 'A' }] },
+      })
+      const fieldArray = useFieldArray(form, 'rows')
+
+      // Pre-register the would-be path before the item exists.
+      const newName = form.getField('rows.1.name')
+
+      fieldArray.pushPristine({ name: 'new' })
+
+      expect(newName.data.value).toBe('new')
+      expect(newName.initialValue.value).toBe('new')
+      expect(newName.dirty.value).toBe(false)
+    })
+
+    it('multiple pushPristine calls anchor each new index independently', () => {
+      type Row = { name: string }
+      const form = useForm<{ rows: Row[] }>({
+        initialData: { rows: [] },
+      })
+      const fieldArray = useFieldArray(form, 'rows')
+
+      fieldArray.pushPristine({ name: 'one' })
+      fieldArray.pushPristine({ name: 'two' })
+
+      expect(form.data.value.rows).toEqual([{ name: 'one' }, { name: 'two' }])
+      expect(form.getField('rows.0.name').dirty.value).toBe(false)
+      expect(form.getField('rows.1.name').dirty.value).toBe(false)
+      expect(fieldArray.field.dirty.value).toBe(true)
+    })
+
+    it('editing a pushPristine item after the fact marks that subfield dirty', () => {
+      type Row = { name: string }
+      const form = useForm<{ rows: Row[] }>({
+        initialData: { rows: [] },
+      })
+      const fieldArray = useFieldArray(form, 'rows')
+
+      fieldArray.pushPristine({ name: 'initial' })
+      const nameField = form.getField('rows.0.name')
+      expect(nameField.dirty.value).toBe(false)
+
+      nameField.setData('edited')
+      expect(nameField.dirty.value).toBe(true)
+    })
+
+    it('regular push leaves the item subfields dirty (contrast)', () => {
+      type Row = { name: string }
+      const form = useForm<{ rows: Row[] }>({
+        initialData: { rows: [] },
+      })
+      const fieldArray = useFieldArray(form, 'rows')
+
+      fieldArray.push({ name: 'plain' })
+      // Without the subtree anchor, the new index's baseline is external
+      // (undefined at rows.0.name) → field is dirty.
+      expect(form.getField('rows.0.name').dirty.value).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Propagate initial data changes down the field tree via a form-level override layer
- Introduces [`useInitialDataOverride`](https://github.com/teamnovu/kit/pull/15/files#diff-c13791c92d81ff865a127decb3f17f4fcf49b7e966dd8daf9efc58d2f18e4867) to manage a form-level baseline override layer that supports deep-merge vs replace semantics and `tree` vs `subtree` scoping, so that calling `setInitialData` on a parent path correctly updates subfields' baselines.
- Refactors [`useFieldRegistry`](https://github.com/teamnovu/kit/pull/15/files#diff-51e9c85bb37e12730cbf0d6b0d0922573be6926f43d6426281a9e205e719476b) so each field's `initialValue` resolves through the override layer (`resolveAt(path)`) rather than reading raw `formState.initialData` directly, and replaces each field's `setInitialData` with a registry-supplied function that writes to the override layer.
- Adds `pushPristine(item)` to `useFieldArray`, which appends an item and anchors its subtree baseline via `setInitialData(item, { scope: 'subtree' })`, so new array items start non-dirty while the array field itself remains dirty.
- Changes `form.reset()` to rebuild data from `effectiveInitialData` (merged external `initialData` plus active overrides) so overrides persist across resets.
- Behavioral Change: reassigning the external `initialData` ref clears all active overrides; `reset` now reflects merged initial data rather than raw `initialData`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92d4e6c.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->