### PR TITLE
Create new package for tanstack query operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "author": "@teamnovu",
   "type": "module",
-  "packageManager": "pnpm@9.11.0",
+  "packageManager": "pnpm@11.7.0+sha512.19cc852c120c7125760f2443ee6be0ca5b40f9f50598de1a09a1f177503e010e57c23c77646e01e761de59bf874fb22a3398c33ab9691fc13eb946b6f0f4d620",
   "scripts": {
     "lint": "eslint . --fix",
     "build": "pnpm -r build",
@@ -24,7 +24,8 @@
     "packages/cookieconsent",
     "packages/shopware-api-client",
     "packages/shopware-composables",
-    "packages/api-platform-types"
+    "packages/api-platform-types",
+    "packages/operations"
   ],
   "devDependencies": {
     "@eslint/compat": "^1.2.9",
@@ -64,6 +65,7 @@
     "@teamnovu/kit-shopware-api-client": "workspace:^",
     "@teamnovu/kit-shopware-composables": "workspace:^",
     "@teamnovu/kit-api-platform-types": "workspace:^",
+    "@teamnovu/kit-operations": "workspace:^",
     "@types/node": "^22.14.1"
   }
 }

--- a/packages/operations/.gitignore
+++ b/packages/operations/.gitignore
@@ -1,0 +1,2 @@
+.env.test
+.env.local

--- a/packages/operations/package.json
+++ b/packages/operations/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@teamnovu/kit-operations",
+  "version": "0.1.0",
+  "description": "",
+  "main": "dist/index.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "vite build",
+    "watch": "NODE_ENV=development vite build --watch",
+    "lint": "eslint --fix --ignore-pattern 'dist/**' .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ui": "vitest --ui"
+  },
+  "keywords": [
+    "vue",
+    "forms",
+    "validation",
+    "typescript"
+  ],
+  "author": "",
+  "license": "ISC",
+  "peerDependencies": {
+    "@tanstack/vue-query": "^5.101.0",
+    "vue": "^3.5.25"
+  },
+  "devDependencies": {
+    "@tanstack/vue-query": "^5.101.0",
+    "@vitejs/plugin-vue": "^6.0.1",
+    "@vitest/ui": "^2.0.0",
+    "vitest": "^2.0.0",
+    "vue": "^3.5.25"
+  },
+  "dependencies": {
+    "lodash-es": "^4.17.21"
+  }
+}

--- a/packages/operations/package.json
+++ b/packages/operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamnovu/kit-operations",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/operations/src/createEndpoints.ts
+++ b/packages/operations/src/createEndpoints.ts
@@ -1,0 +1,68 @@
+import { type DefaultError, type QueryKey } from '@tanstack/vue-query'
+import { mapValues } from 'lodash-es'
+import { unref } from 'vue'
+import type {
+  ApiParams,
+  QueryEndpoint,
+  EndpointParams,
+  Endpoints,
+  MappedEndpoints,
+} from './types'
+
+function mapKeyFn<
+  QueryFnOutput,
+  Params extends ApiParams,
+  Key extends QueryKey,
+  T extends QueryEndpoint<Output, Params, Error, Key>,
+  Path extends QueryKey,
+  Error = DefaultError,
+  Output = QueryFnOutput,
+>(path: Path, fn: T): QueryEndpoint<QueryFnOutput, Params, Error, [...Path, ...Key], Output> {
+  const endpoint = (...rest: EndpointParams<Params>) => {
+    const result = fn(...rest)
+    return {
+      ...result,
+      queryKey: [...path, ...unref(unref(result).queryKey)] as [...Path, ...Key],
+      $invalidateKey: [...path, ...unref(unref(result).$invalidateKey)] as [...Path, ...Key],
+    } as const
+  }
+
+  endpoint.$invalidateKey = path
+
+  return endpoint as unknown as QueryEndpoint<QueryFnOutput, Params, Error, [...Path, ...Key], Output>
+}
+
+/**
+ * Takes a tree of endpoint definitions and prepends each nesting key to the query keys,
+ * enabling hierarchical cache invalidation. Also adds `$invalidateKey` at each level.
+ *
+ * @example
+ * const endpoints = createEndpoints({
+ *   company: {
+ *     process: query<ProcessOutput>().url('/api/processes/:processId').build(),
+ *   },
+ * });
+ * // endpoints.company.process({ params: { processId } }) → queryKey: ['company', 'process', { processId }]
+ * // endpoints.company.$invalidateKey → ['company']
+ */
+export function createEndpoints<T extends Endpoints>(keys: T): MappedEndpoints<T> {
+  const walk = <TInner extends Endpoints, Key extends QueryKey>(obj: TInner, path: Key) => {
+    const values = mapValues(obj, (value, key): Endpoints[string] => {
+      if (typeof value === 'function') {
+        if (value.$brand === 'QueryEndpoint') {
+          return mapKeyFn([...path, key], value)
+        } else {
+          return value
+        }
+      }
+
+      return walk(value, [...path, key])
+    }) as MappedEndpoints<TInner, Key>
+
+    values.$invalidateKey = path
+
+    return values
+  }
+
+  return walk(keys, [])
+};

--- a/packages/operations/src/fetcher.ts
+++ b/packages/operations/src/fetcher.ts
@@ -1,0 +1,63 @@
+import type { MutationFunction, QueryFunction, QueryKey } from '@tanstack/vue-query'
+import { type InjectionKey, type MaybeRef, inject } from 'vue'
+
+/**
+ * The two transport halves are deliberately *not* the same shape — queries and
+ * mutations have genuinely different needs (deferred signal handling vs. method
+ * negotiation, body/filter ingestion, custom headers). They share only the
+ * injection mechanism: the consumer wires both up in a single `provide`.
+ */
+
+type QueryMutationParams = string[][] | Record<string, string> | string | URLSearchParams
+
+export type CustomFetchInit = Omit<NonNullable<RequestInit>, 'body'> & {
+  query?: QueryMutationParams
+  body?: unknown
+} | undefined
+
+export type CustomFetch = <T = unknown>(url: string, init?: CustomFetchInit) => Promise<T>
+
+export type QueryFnParams = [
+  url: MaybeRef<string>,
+  queryParams?: MaybeRef<Record<string, unknown> | undefined>,
+  options?: MaybeRef<Omit<RequestInit, 'signal'>>,
+]
+
+/**
+ * Query transport. A *factory* that returns a `QueryFunction`, so the actual fetch
+ * can read `context.signal` at execution time. Params are known up front.
+ */
+export type QueryFnFactory = <T = unknown, K extends QueryKey = QueryKey>(
+  ...params: QueryFnParams
+) => QueryFunction<T, K>
+
+export interface OperationsTransport {
+  query: QueryFnFactory
+  mutation: CustomFetch
+}
+
+export const transportKey: InjectionKey<OperationsTransport> = Symbol('operations:transport')
+
+export function useTransport(): OperationsTransport {
+  const transport = inject(transportKey, null)
+  if (!transport) {
+    throw new Error(
+      '[operations] No transport provided. Call app.provide(transportKey, { query, mutation }) '
+      + '(or use the Nuxt plugin) before invoking endpoints.',
+    )
+  }
+  return transport
+}
+
+export function makeQueryFn<T = unknown, K extends QueryKey = QueryKey>(
+  ...params: QueryFnParams
+): QueryFunction<T, K> {
+  return useTransport().query<T, K>(...params)
+}
+
+export function useMutationFn<TResult, TParams>(
+  fn: (call: CustomFetch, params: TParams) => Promise<TResult>,
+): MutationFunction<TResult, TParams> {
+  const { mutation } = useTransport()
+  return (params: TParams) => fn(mutation, params)
+}

--- a/packages/operations/src/fetcher.ts
+++ b/packages/operations/src/fetcher.ts
@@ -38,12 +38,29 @@ export interface OperationsTransport {
 
 export const transportKey: InjectionKey<OperationsTransport> = Symbol('operations:transport')
 
+/**
+ * Module-level fallback for the transport. Used when no `inject` context is
+ * available — e.g. endpoints invoked imperatively outside `setup()` (router
+ * guards, async handlers, bootstrap prefetch). Safe for client-only SPAs; for
+ * SSR prefer `app.provide(transportKey, …)` so the transport stays request-scoped.
+ */
+let moduleTransport: OperationsTransport | null = null
+
+/** Registers the module-level fallback transport. */
+export function setTransport(transport: OperationsTransport): void {
+  moduleTransport = transport
+}
+
+/**
+ * Resolves the transport at endpoint-invocation time. Prefers an injected
+ * transport (request-scoped), falling back to the module-level one. Throws if neither is set.
+ */
 export function useTransport(): OperationsTransport {
-  const transport = inject(transportKey, null)
+  const transport = inject(transportKey, null) ?? moduleTransport
   if (!transport) {
     throw new Error(
-      '[operations] No transport provided. Call app.provide(transportKey, { query, mutation }) '
-      + '(or use the Nuxt plugin) before invoking endpoints.',
+      '[operations] No transport provided. Call setTransport({ query, mutation }) or '
+      + 'app.provide(transportKey, { query, mutation }) before invoking endpoints.',
     )
   }
   return transport

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -1,0 +1,8 @@
+export * from './types'
+export * from './fetcher'
+export * from './query'
+export * from './mutation'
+export * from './createEndpoints'
+export * from './resourceRegistry'
+export * from './iri'
+export { deepUnwrapParams } from './unwrapParams'

--- a/packages/operations/src/iri.ts
+++ b/packages/operations/src/iri.ts
@@ -1,12 +1,12 @@
-type IriInput = string | undefined | null;
+type IriInput = string | undefined | null
 
 export function getIdFromIRI(iri: string | undefined | null): string | undefined {
-  const match = iri?.match(/\/api\/[^/]+\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i);
+  const match = iri?.match(/\/api\/[^/]+\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i)
   if (!match) {
-    return undefined;
+    return undefined
   }
-  const [_, id] = match;
-  return id;
+  const [_, id] = match
+  return id
 }
 
 /**
@@ -27,7 +27,7 @@ export function getIdFromIRI(iri: string | undefined | null): string | undefined
 export function mapArrayOfIdFromIRI(list: IriInput[] | undefined): string[] {
   return (list ?? [])
     .map(item => getIdFromIRI(item))
-    .filter((id: string | undefined): id is string => id !== undefined);
+    .filter((id: string | undefined): id is string => id !== undefined)
 }
 
 /**
@@ -42,5 +42,5 @@ export function mapIdFromIRIByKey<T>(
 ): string[] {
   return (list ?? [])
     .map(item => getIdFromIRI(item[key] as IriInput))
-    .filter((id: string | undefined): id is string => id !== undefined);
+    .filter((id: string | undefined): id is string => id !== undefined)
 }

--- a/packages/operations/src/iri.ts
+++ b/packages/operations/src/iri.ts
@@ -1,7 +1,12 @@
 type IriInput = string | undefined | null
 
 export function getIdFromIRI(iri: string | undefined | null): string | undefined {
-  const match = iri?.match(/\/api\/[^/]+\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i)
+  // Guard against non-string values reaching `.match()` (callers may cast through
+  // `IriInput`, e.g. `mapIdFromIRIByKey`), which would throw a runtime TypeError.
+  if (typeof iri !== 'string') {
+    return undefined
+  }
+  const match = iri.match(/\/api\/[^/]+\/([^/?#]+)/)
   if (!match) {
     return undefined
   }

--- a/packages/operations/src/iri.ts
+++ b/packages/operations/src/iri.ts
@@ -1,0 +1,46 @@
+type IriInput = string | undefined | null;
+
+export function getIdFromIRI(iri: string | undefined | null): string | undefined {
+  const match = iri?.match(/\/api\/[^/]+\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i);
+  if (!match) {
+    return undefined;
+  }
+  const [_, id] = match;
+  return id;
+}
+
+/**
+ * Takes a flat array of IRIs and transforms it into an array of numeric IDs.
+ *
+ * Input,
+ * ```
+ * ['/api/company_processes/1', '/api/company_processes/2', '/api/company_processes/3']
+ * ```
+ *
+ * Would become:
+ * ```
+ * [1, 2, 3]
+ * ```
+ *
+ * It additionally guarantees that the returned array doesn't contain undefined values.
+ */
+export function mapArrayOfIdFromIRI(list: IriInput[] | undefined): string[] {
+  return (list ?? [])
+    .map(item => getIdFromIRI(item))
+    .filter((id: string | undefined): id is string => id !== undefined);
+}
+
+/**
+ * Takes an array objects and returns an array of numeric IDs. The IRI is read from each objects
+ * according to the provided key (defaults to '@id').
+ *
+ * It additionally guarantees that the returned array doesn't contain undefined values.
+ */
+export function mapIdFromIRIByKey<T>(
+  list: T[] | undefined,
+  key: keyof T = '@id' as keyof T,
+): string[] {
+  return (list ?? [])
+    .map(item => getIdFromIRI(item[key] as IriInput))
+    .filter((id: string | undefined): id is string => id !== undefined);
+}

--- a/packages/operations/src/mutation.ts
+++ b/packages/operations/src/mutation.ts
@@ -1,0 +1,139 @@
+import { type DefaultError } from '@tanstack/vue-query'
+import { mapValues } from 'lodash-es'
+import { computed, type MaybeRef, unref, type UnwrapRef } from 'vue'
+import type {
+  ApiMutationParams,
+  ApiParams,
+  MutateInput,
+  MutationEndpoint,
+  MutationOptions,
+  UrlOptions,
+  UrlParams,
+} from './types'
+import { deepUnwrapParams } from './unwrapParams'
+
+type EndpointDefinition<
+  Data,
+  Variables,
+  Error = DefaultError,
+  Options extends RequestInit = RequestInit,
+> = MutationOptions<Data, Error, Variables> & {
+  options?: MaybeRef<Options>
+}
+
+/** Transforms the mutation input bag (`{ body } & path/query params`) before it's sent. */
+type MutationParamsFn<Variables> = (params: Variables) => Variables
+
+function buildEndpoint<
+  Data,
+  InputData,
+  Url extends UrlOptions<string, never>,
+  Params extends ApiMutationParams<UrlParams<Url>>,
+  Error = DefaultError,
+  Options extends RequestInit = RequestInit,
+>(
+  url: Url | undefined,
+  paramsFn?: MutationParamsFn<MutateInput<InputData, Params>>,
+  factory?: () => EndpointDefinition<Data, MutateInput<InputData, Params>, Error, Options>,
+): MutationEndpoint<Data, MutateInput<InputData, Params>, Error> {
+  const endpoint = (<OverridenData extends Data = Data>(options?: MaybeRef<RequestInit>) => {
+    const directFetchOptions = options as Options | undefined
+    const definition = factory?.() ?? {} as EndpointDefinition<Data, MutateInput<InputData, Params>>
+
+    type ParamKeys = Exclude<keyof UnwrapRef<ApiParams>, 'body'>
+
+    const unrefParams = <Key extends ParamKeys>(params: Params, key: Key) => {
+      if (!params) return params
+      const unrefedOnce = unref(params)[key]
+      if (!unrefedOnce) return undefined
+      const unrefedParams = unref(unrefedOnce)
+      return mapValues(
+        unrefedParams,
+        v => unref(v),
+      ) as Record<string, UnwrapRef<Params['params']>> | undefined
+    }
+
+    const resolveUrl = (receivedParams: Record<string, unknown> | undefined) => {
+      const resolvedUrl = (typeof url === 'function' ? url((receivedParams as never) ?? {}) : url as string | undefined) ?? ''
+      return resolvedUrl.replace(/:([a-zA-Z0-9_]+)/g, (_, param: string) => receivedParams?.[param] as string || '')
+    }
+
+    const queryFnOptions = computed(() => ({
+      ...unref(definition.options),
+      ...unref(directFetchOptions),
+    }))
+
+    return {
+      ...definition,
+      mutationFn: useMutationFn<OverridenData, MutateInput<InputData, Params>>(
+        (call, data) => {
+          // Imperative: params arrive at mutate() time, so transform once here.
+          const resolved = paramsFn ? paramsFn(deepUnwrapParams(data)) : data
+
+          return call(resolveUrl(unrefParams(resolved, 'params')), {
+            method: 'POST',
+            body: resolved.body,
+            ...queryFnOptions.value,
+          })
+        },
+      ),
+    }
+  }) as ((...rest: unknown[]) => unknown) & { $brand?: string }
+
+  endpoint.$brand = 'MutationEndpoint'
+
+  return endpoint as MutationEndpoint<
+    Data,
+    MutateInput<InputData, Params>,
+    Error
+  >
+}
+
+/**
+ * Builder for type-safe endpoint definitions. Chains `mutation<OutputType, InputType>().url('/path/:param').build()`
+ * to create an `Endpoint` that auto-generates mutation options and handles URL interpolation.
+ *
+ * The return type is wrapped in `NoInfer<Endpoint<...>>` to prevent TypeScript from using the
+ * return type for generic inference while keeping the `Endpoint`'s internal generic params clean
+ * (so that conditional types like `Exclude` can distribute over the output type).
+ *
+ * @typeParam QueryFnOutput - The raw data type the API returns
+ *
+ * @example
+ * // Simple endpoint
+ * const patchProcess = mutation<ProcessOutput, ProcessInput>()
+ *   .url('/api/processes/:processId')
+ *   .build(() => ({
+ *     options: {
+ *      method: 'PATCH',
+ *     },
+ *   }));
+ */
+export const mutation = <Data = unknown, InputData = unknown, Error = DefaultError>() => {
+  const tail = <
+    Url extends UrlOptions<string, never>,
+  >(
+    url?: Url,
+    paramsFn?: MutationParamsFn<MutateInput<InputData, ApiParams<UrlParams<Url>>>>,
+  ) => ({
+    params: (
+      paramsFn?: MutationParamsFn<MutateInput<InputData, ApiParams<UrlParams<Url>>>>,
+    ) => tail(url, paramsFn),
+    build: <
+      Params extends ApiParams<UrlParams<Url>> = ApiParams<UrlParams<Url>>,
+      Options extends RequestInit = RequestInit,
+    >(
+      factory?: () => EndpointDefinition<Data, MutateInput<InputData, Params>, Error, Options>,
+    ): NoInfer<MutationEndpoint<Data, MutateInput<InputData, Params>, Error>> =>
+      buildEndpoint<Data, InputData, Url, Params, Error, Options>(
+        url,
+        paramsFn as MutationParamsFn<MutateInput<InputData, Params>> | undefined,
+        factory,
+      ),
+  })
+
+  return {
+    url: <Url extends UrlOptions<string, never>>(url: Url) => tail(url),
+    ...tail(),
+  }
+}

--- a/packages/operations/src/mutation.ts
+++ b/packages/operations/src/mutation.ts
@@ -11,6 +11,7 @@ import type {
   UrlParams,
 } from './types'
 import { deepUnwrapParams } from './unwrapParams'
+import { useMutationFn } from './fetcher'
 
 type EndpointDefinition<
   Data,

--- a/packages/operations/src/query.ts
+++ b/packages/operations/src/query.ts
@@ -25,6 +25,7 @@ import {
   serializeResource,
 } from './resourceRegistry'
 import { deepUnwrapParams } from './unwrapParams'
+import { makeQueryFn } from './fetcher'
 
 type EndpointDefinition<
   QueryFnOutput,

--- a/packages/operations/src/query.ts
+++ b/packages/operations/src/query.ts
@@ -1,0 +1,235 @@
+import {
+  type DefaultError,
+  hashKey,
+  type QueryFunctionContext,
+  type QueryKey,
+} from '@tanstack/vue-query'
+import { mapValues } from 'lodash-es'
+import { computed, type MaybeRef, unref, type UnwrapRef } from 'vue'
+import type {
+  ApiParams,
+  EndpointParams,
+  MaybeParams,
+  QueryEndpoint,
+  QueryKeyFromParams,
+  QueryOptions,
+  QueryParamsFn,
+  Resource,
+  UrlOptions,
+  UrlParams,
+} from './types'
+import {
+  extractResourceTypes,
+  registerQueryResources,
+  resourceIndex,
+  serializeResource,
+} from './resourceRegistry'
+import { deepUnwrapParams } from './unwrapParams'
+
+type EndpointDefinition<
+  QueryFnOutput,
+  Error = DefaultError,
+  Options extends RequestInit = RequestInit,
+  Key extends QueryKey = QueryKey,
+  Output = QueryFnOutput,
+> = Omit<QueryOptions<QueryFnOutput, Error, Key, Output>, 'queryKey'> & {
+  options?: MaybeRef<Options>
+}
+
+/**
+ * Unwraps all reactive refs in an endpoint's query options, producing plain values
+ * suitable for `queryClient.fetchQuery`. Strips `initialData` since it's not applicable
+ * to imperative fetches.
+ *
+ * @example
+ * const opts = endpoints.involvedPerson.bulk({ body: computed(() => ({ ids })) });
+ * const data = await queryClient.fetchQuery(toFetchOptions(opts));
+ */
+export function toFetchOptions<T extends Record<string, unknown>>(
+  opts: T,
+): Omit<{ [K in keyof T]: UnwrapRef<T[K]> }, 'initialData'> {
+  return Object.fromEntries(
+    Object.entries(opts).map(([k, v]) => [k, unref(v)]),
+  ) as { [K in keyof T]: UnwrapRef<T[K]> }
+}
+
+function buildEndpoint<
+  QueryFnOutput,
+  Url extends UrlOptions<string, never>,
+  Params extends ApiParams<UrlParams<Url>>,
+  Error = DefaultError,
+  Options extends RequestInit = RequestInit,
+  Key extends QueryKey = QueryKey,
+  Output = QueryFnOutput,
+>(
+  url: Url | undefined,
+  resources: Resource[] | undefined,
+  paramsFn?: QueryParamsFn<Params>,
+  factory?: (...rest: MaybeParams<Params, [params: Params]>) => EndpointDefinition<QueryFnOutput, Error, Options, Key, Output>,
+): QueryEndpoint<QueryFnOutput, Params, Error, Key, Output> {
+  const endpoint = (<OverriddenQueryFnOutput extends QueryFnOutput = QueryFnOutput>(...rest: EndpointParams<Params>) => {
+    const transformed = computed(() => paramsFn!(deepUnwrapParams(rest[0]) as Params))
+    const section = (key: keyof ApiParams) => {
+      const bag = transformed.value
+      return bag[key] !== undefined ? computed(() => transformed.value[key]) : undefined
+    }
+    const params = paramsFn
+      ? {
+          params: section('params'),
+          body: section('body'),
+          queryParams: section('queryParams'),
+        } as Params
+      : (rest[0] as Params | undefined)
+
+    const directFetchOptions = rest[1] as Options | undefined
+    const definition = factory?.(...[params] as MaybeParams<Params, [params: Params]>) ?? {} as EndpointDefinition<QueryFnOutput>
+
+    type ParamKeys = Exclude<keyof UnwrapRef<ApiParams>, 'body'>
+
+    const twoStepUnrefParams = <Key extends ParamKeys>(key: Key) => {
+      if (!params) return params
+      const unrefedOnce = unref(params)[key]
+      if (!unrefedOnce) return undefined
+      const unrefedParams = unref(unrefedOnce)
+      return mapValues(
+        unrefedParams,
+        v => unref(v),
+      ) as Record<string, UnwrapRef<Params['params']>> | undefined
+    }
+
+    const queryKey = [params?.params, params?.body, params?.queryParams].filter(Boolean) as QueryKeyFromParams<Params>
+
+    const $invalidateKey = [
+      twoStepUnrefParams('params'),
+      unref(params?.body),
+      twoStepUnrefParams('queryParams'),
+    ].filter(Boolean) as unknown as Key
+
+    const concreteUrl = computed(() => {
+      const receivedParams = twoStepUnrefParams('params')
+      const resolvedUrl = (typeof url === 'function' ? url((receivedParams as never) ?? {}) : url as string | undefined) ?? ''
+      return resolvedUrl.replace(/:([a-zA-Z0-9_]+)/g, (_, param: string) => receivedParams?.[param] as string || '')
+    })
+
+    const queryFnOptions = computed(() => ({
+      ...unref(definition.options),
+      ...unref(directFetchOptions),
+    }))
+
+    const queryFn = makeQueryFn<OverriddenQueryFnOutput>(
+      concreteUrl,
+      computed(() => twoStepUnrefParams('queryParams') ?? undefined),
+      queryFnOptions,
+    )
+
+    const concreteQueryFn = async (ctx: QueryFunctionContext) => {
+      const data = await queryFn(ctx)
+
+      const resourceKey = !twoStepUnrefParams('queryParams') ? ctx.queryKey : ctx.queryKey.slice(0, -1)
+
+      if (resources?.length) {
+        for (const r of resources) {
+          const map = resourceIndex.get(serializeResource(r)) ?? new Map()
+          map.set(hashKey(resourceKey), resourceKey)
+          resourceIndex.set(serializeResource(r), map)
+        }
+      }
+
+      registerQueryResources(extractResourceTypes(data), resourceKey)
+
+      return data
+    }
+
+    return {
+      ...definition,
+      $invalidateKey,
+      queryKey,
+      queryFn: url ? concreteQueryFn : ('queryFn' in definition ? definition.queryFn : undefined),
+      enabled: computed(() => {
+        const unrefedParams = twoStepUnrefParams('params')
+        if (!unrefedParams) return true
+
+        return Object.values(unrefedParams).every(v => v !== undefined && v !== null)
+      }),
+    }
+  }) as ((...rest: unknown[]) => unknown) & { $brand?: string }
+
+  endpoint.$brand = 'QueryEndpoint'
+
+  return endpoint as QueryEndpoint<
+    QueryFnOutput,
+    Params,
+    Error,
+    Key,
+    Output
+  >
+}
+
+/**
+ * Builder for type-safe endpoint definitions. Chains `query<OutputType>().url('/path/:param').build()`
+ * to create an `Endpoint` that auto-generates query keys from parameters and handles URL interpolation.
+ *
+ * Optionally chain `.resources()` before `.build()` to declare which resource types appear in the
+ * endpoint's response, enabling automatic cache invalidation when those resources are mutated.
+ *
+ * The return type is wrapped in `NoInfer<Endpoint<...>>` to prevent TypeScript from using the
+ * return type for generic inference while keeping the `Endpoint`'s internal generic params clean
+ * (so that conditional types like `Exclude` can distribute over the output type).
+ *
+ * @typeParam QueryFnOutput - The raw data type the API returns
+ *
+ * @example
+ * // Simple endpoint
+ * const getProcess = query<ProcessOutput>()
+ *   .url('/api/processes/:processId')
+ *   .build();
+ *
+ * // Endpoint with resource tags for cache invalidation
+ * const getProcess = query<ProcessOutput>()
+ *   .url('/api/processes/:processId')
+ *   .resources('CompanyProcess', 'User')
+ *   .build();
+ *
+ * // Endpoint with select (Output inferred from select return type)
+ * const getPlz = query<PlzResponse>()
+ *   .url('/api/plz_request')
+ *   .build((params) => ({
+ *     select: (data) => data.result,
+ *     enabled: computed(() => !!params.queryParams?.plz),
+ *   }));
+ *
+ * // Endpoint without URL (custom queryFn via factory)
+ * const custom = query<CustomOutput>()
+ *   .build(() => ({
+ *     queryFn: () => fetchCustomData(),
+ *   }));
+ */
+export const query = <QueryFnOutput, Error = DefaultError>() => {
+  const tail = <
+    Url extends UrlOptions<string, never>,
+  >(url?: Url, resources?: Resource[], paramsFn?: QueryParamsFn<ApiParams<UrlParams<Url>>>) => ({
+    resources: (...tags: Resource[]) => tail(url, tags, paramsFn),
+    params: (
+      paramsFn?: QueryParamsFn<ApiParams<UrlParams<Url>>>,
+    ) => tail(url, resources, paramsFn),
+    build: <
+      Params extends ApiParams<UrlParams<Url>> = ApiParams<UrlParams<Url>>,
+      Key extends QueryKey = QueryKeyFromParams<Params>,
+      Options extends RequestInit = RequestInit,
+      Output = QueryFnOutput,
+    >(
+      factory?: (params: Params) => EndpointDefinition<QueryFnOutput, Error, Options, Key, Output>,
+    ): NoInfer<QueryEndpoint<QueryFnOutput, Params, Error, QueryKeyFromParams<Params>, Output>> =>
+      buildEndpoint<QueryFnOutput, Url, Params, Error, Options, QueryKeyFromParams<Params>, Output>(
+        url,
+        resources,
+        paramsFn,
+        factory as ((params?: Params) => EndpointDefinition<QueryFnOutput, Error, Options, QueryKeyFromParams<Params>, Output>) | undefined,
+      ),
+  })
+
+  return {
+    url: <Url extends UrlOptions<string, never>>(url: Url) => tail(url),
+    ...tail(),
+  }
+}

--- a/packages/operations/src/query.ts
+++ b/packages/operations/src/query.ts
@@ -141,16 +141,27 @@ function buildEndpoint<
       return data
     }
 
+    // Gate the query on all path params being present (a missing path param
+    // would produce a broken URL). ANDed with any user-provided `enabled` so
+    // custom logic from the factory is preserved rather than clobbered.
+    const paramsPresent = computed(() => {
+      const unrefedParams = twoStepUnrefParams('params')
+      if (!unrefedParams) return true
+
+      return Object.values(unrefedParams).every(v => v !== undefined && v !== null)
+    })
+
+    const userEnabled = definition.enabled
+
     return {
       ...definition,
       $invalidateKey,
       queryKey,
       queryFn: url ? concreteQueryFn : ('queryFn' in definition ? definition.queryFn : undefined),
       enabled: computed(() => {
-        const unrefedParams = twoStepUnrefParams('params')
-        if (!unrefedParams) return true
-
-        return Object.values(unrefedParams).every(v => v !== undefined && v !== null)
+        if (!paramsPresent.value) return false
+        // `enabled` is documented for this builder as boolean | Ref | computed.
+        return userEnabled === undefined ? true : !!unref(userEnabled)
       }),
     }
   }) as ((...rest: unknown[]) => unknown) & { $brand?: string }

--- a/packages/operations/src/resourceRegistry.ts
+++ b/packages/operations/src/resourceRegistry.ts
@@ -33,6 +33,20 @@ export function registerQueryResources(resources: Set<Resource>, queryKey: Query
 }
 
 /**
+ * Like `queryClient.setQueryData`, but also registers the resources contained in `data`
+ * in the resource index. Bare `setQueryData` bypasses the fetch path, leaving the seeded
+ * entry invisible to `invalidateResources`.
+ */
+export function setQueryDataWithResources<T>(
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+  data: T,
+): void {
+  queryClient.setQueryData(queryKey, data);
+  registerQueryResources(extractResourceTypes(data), queryKey);
+}
+
+/**
  * Recursively walks a JSON-LD response and collects all `@type` values.
  * Handles single resources, hydra collections, and nested objects.
  */

--- a/packages/operations/src/resourceRegistry.ts
+++ b/packages/operations/src/resourceRegistry.ts
@@ -1,0 +1,143 @@
+import { getIdFromIRI } from './iri'
+import { hashKey, type QueryClient, type QueryKey } from '@tanstack/vue-query'
+import type { AtType, Id, Resource } from './types'
+
+/** Global registry: serialized resource → (hashed query key → query key). */
+export const resourceIndex = new Map<string, Map<string, QueryKey>>()
+
+export function serializeResource(resource: Resource): string {
+  return typeof resource === 'string'
+    ? resource
+    : resource[1]
+      ? `${resource[0]}\0${resource[1]}`
+      : resource[0]
+}
+
+export function registerQueryResources(resources: Set<Resource>, queryKey: QueryKey): void {
+  const qKey = hashKey(queryKey)
+
+  const newRKeys = new Set<string>()
+  for (const resource of resources) {
+    newRKeys.add(serializeResource(resource))
+  }
+
+  // Register queryKey under current resources
+  for (const rKey of newRKeys) {
+    let map = resourceIndex.get(rKey)
+    if (!map) {
+      map = new Map()
+      resourceIndex.set(rKey, map)
+    }
+    map.set(qKey, queryKey)
+  }
+}
+
+/**
+ * Recursively walks a JSON-LD response and collects all `@type` values.
+ * Handles single resources, hydra collections, and nested objects.
+ */
+export function extractResourceTypes(data: unknown): Set<Resource> {
+  const types = new Set<Resource>()
+
+  const getId = (obj: Record<string, unknown>): Id | undefined => {
+    return typeof obj.id === 'string'
+      ? obj.id
+      : getIdFromIRI(obj['@id'] as string | undefined)
+  }
+
+  function walk(obj: unknown): void {
+    if (obj === null || obj === undefined || typeof obj !== 'object') {
+      return
+    }
+
+    if (Array.isArray(obj)) {
+      for (const item of obj) {
+        walk(item)
+      };
+
+      return
+    }
+
+    const record = obj as Record<string, unknown>
+    const id = getId(record)
+
+    if (typeof record['@type'] === 'string') {
+      if (id) {
+        types.add([record['@type'] as AtType, id])
+      }
+    }
+
+    for (const value of Object.values(record)) {
+      if (typeof value === 'object' && value !== null) {
+        walk(value)
+      }
+    }
+  }
+
+  walk(data)
+  return types
+}
+
+/**
+ * Invalidates all cached queries that have returned data containing the given resource type(s).
+ * Uses the global resource index populated automatically when query functions fetch data.
+ * Resources declared via `.resources()` in the endpoint builder are also pre-registered.
+ *
+ * Stale entries (query keys no longer in the cache) are pruned lazily on each call.
+ *
+ * @example
+ * // In a mutation's onSuccess:
+ * await invalidateResources(queryClient, 'User');
+ *
+ * // Multiple resources at once:
+ * await invalidateResources(queryClient, 'NatPerson', 'InvolvedPerson');
+ *
+ * // Specific resource instance:
+ * await invalidateResources(queryClient, ['User', userId]);
+ */
+export function invalidateResources(
+  queryClient: QueryClient,
+  ...resources: Resource[]
+): Promise<void[]> {
+  const cache = queryClient.getQueryCache()
+
+  const uniqueKeys = new Map<string, QueryKey>()
+
+  for (const resource of resources) {
+    const rKeys: string[] = [serializeResource(resource)]
+
+    // A plain AtType tag also matches all id-specific tags of that type
+    if (typeof resource === 'string' || !resource[1]) {
+      const exact = typeof resource === 'string' ? resource : resource[0]
+      const prefix = `${exact}\0`
+      for (const key of resourceIndex.keys()) {
+        if (key.startsWith(prefix) || key === exact) {
+          rKeys.push(key)
+        }
+      }
+    }
+
+    for (const rKey of rKeys) {
+      const map = resourceIndex.get(rKey)
+      if (!map) continue
+
+      for (const [qKey, queryKey] of map) {
+        if (cache.find({
+          queryKey,
+          exact: false,
+        })) {
+          uniqueKeys.set(qKey, queryKey)
+        } else {
+          map.delete(qKey)
+        }
+      }
+    }
+  }
+
+  return Promise.all(
+    [...uniqueKeys.values()].map(queryKey =>
+      queryClient.invalidateQueries({
+        queryKey,
+      })),
+  )
+}

--- a/packages/operations/src/types.ts
+++ b/packages/operations/src/types.ts
@@ -1,0 +1,318 @@
+import type { UseMutationOptions } from '@tanstack/vue-query'
+import {
+  type DefaultError,
+  type QueryKey,
+  type UndefinedInitialQueryOptions,
+} from '@tanstack/vue-query'
+import { type MaybeRef } from 'vue'
+
+type ParamsBase = Record<string, unknown>
+
+// For module augmentation
+export interface OperationsOverrides {
+  OperationsUnionType: { type: string }
+}
+
+export type AtType = OperationsOverrides['OperationsUnionType']['type']
+export type Id = string
+export type Resource = AtType | readonly [AtType, Id | undefined]
+
+export type MaybeParams<Params extends ApiParams, T> = [Params] extends [never]
+  ? []
+  : Params extends ApiParams<infer P>
+    ? keyof P extends never
+      ? Partial<T>
+      : T
+    : T
+
+export type QueryKeyFromParams<P extends ApiParams> = P extends ApiParams<infer Path, infer Query, infer Body>
+  ? [
+      ...(keyof Path extends never ? [] : [ShallowMaybeRef<Path>]),
+      ...(unknown extends Body ? [] : [MaybeRef<Body>]),
+      ...(string extends keyof Query ? [] : [ShallowMaybeRef<Query>]),
+    ]
+  : QueryKey
+
+type NonLossyKeys = 'queryKey' | 'queryFn'
+
+type LossyBaseQueryOptions<Key extends QueryKey, Error = DefaultError> = Extract<
+  // oxlint-disable-next-line typescript/no-explicit-any
+  UndefinedInitialQueryOptions<any, Error, any, Key>,
+  { queryFn?: unknown }
+>
+
+/**
+ * Vue Query options compatible with `useQuery`. Extracts the non-Ref variant
+ * from `UndefinedInitialQueryOptions` so properties can be individually reactive
+ * (via `MaybeRefDeep`) rather than the entire options object being a Ref.
+ *
+ * @typeParam QueryFnOutput - The raw data type returned by the query function
+ (`TQueryFnData`)
+ * @typeParam Key - The query key tuple type
+ * @typeParam Output - The transformed data type after `select` (`TData`), defaults to
+ `QueryFnOutput`
+ */
+export type QueryOptions<
+  QueryFnOutput,
+  Error = DefaultError,
+  Key extends QueryKey = QueryKey,
+  Output = QueryFnOutput,
+> = Extract<
+  UndefinedInitialQueryOptions<QueryFnOutput, Error, Output, Key>,
+  { queryFn?: unknown }
+>
+
+type MutationFnExtractor<T, U> = Extract<T, T extends (...args: never[]) => unknown
+  ? T
+  : T extends object
+    ? U
+    : T>
+
+export type MutationOptions<
+  Data = unknown,
+  Error = DefaultError,
+  Variables = void,
+  OnMutateResult = unknown,
+> = MutationFnExtractor<
+  UseMutationOptions<Data, Error, Variables, OnMutateResult>,
+  {
+    mutationFn?: unknown
+  }
+>
+
+/**
+ * A covariant-safe subset of `QueryOptions` that preserves type-safety for `queryKey` and `queryFn`
+ * while widening all other properties (like `enabled`, `staleTime`) to `any`-based variants.
+ * This avoids contravariance issues from callback-typed properties when constraining
+ * an endpoint's output type (e.g. in `useCachedBulkOperation`).
+ *
+ * Use `LossyCovariantEndpoint` (which uses this type) when you need to accept
+ * endpoints with a specific output type as function parameters.
+ */
+export type LossyCovariantQueryOptions<
+  QueryFnOutput,
+  Error = DefaultError,
+  Key extends QueryKey = QueryKey,
+  Output = QueryFnOutput,
+> = Pick<QueryOptions<QueryFnOutput, Error, Key, Output>, NonLossyKeys>
+  & Omit<LossyBaseQueryOptions<Key>, NonLossyKeys>
+
+/**
+ * Identity at runtime — retypes strict `QueryOptions` as their lossy variant.
+ * Use at call sites where vue-query's invariant generics (e.g. `useQueries`)
+ * reject the precise callback types on `enabled` / `refetchInterval`.
+ */
+export const toLossyQueryOptions = <
+  QueryFnOutput,
+  Error,
+  Key extends QueryKey,
+  Output,
+>(
+  options: QueryOptions<QueryFnOutput, Error, Key, Output> & { $invalidateKey: Key },
+): LossyCovariantQueryOptions<QueryFnOutput, Error, Key, Output> & { $invalidateKey: Key } =>
+  options as unknown as LossyCovariantQueryOptions<QueryFnOutput, Error, Key, Output> & { $invalidateKey: Key }
+
+type ShallowMaybeRef<T> = MaybeRef<{
+  [K in keyof T]: MaybeRef<T[K]>
+}>
+
+/** URL query string parameters (e.g. `?ids=1,2`), each individually reactive. */
+export interface ApiQueryParams<Params extends ParamsBase = ParamsBase> {
+  queryParams?: ShallowMaybeRef<Params>
+};
+/** URL path parameters (e.g. `:processId`), each individually reactive. */
+export interface ApiPathParams<Params extends ParamsBase = ParamsBase> {
+  params?: ShallowMaybeRef<Params>
+};
+/** Request body, reactive as a whole. */
+export interface ApiBodyParams<Params = unknown> {
+  body?: MaybeRef<Params>
+};
+/**
+ * Combined parameter bag for an endpoint call. Merges path params, query params, and body.
+ * Path and query params are `ShallowMaybeRef` (each property individually reactive),
+ * while body is `MaybeRef` (reactive as a whole).
+ */
+export interface ApiParams<
+  Params extends ParamsBase = ParamsBase,
+  QueryParams extends ParamsBase = ParamsBase,
+  BodyParams = unknown,
+> extends
+  ApiPathParams<Params>,
+  ApiQueryParams<QueryParams>,
+  ApiBodyParams<BodyParams> {};
+
+export interface ApiMutationParams<
+  Params extends ParamsBase = ParamsBase,
+  QueryParams extends ParamsBase = ParamsBase,
+> extends
+  ApiPathParams<Params>,
+  ApiQueryParams<QueryParams> {};
+
+type UrlParamNames<Url extends string> = Url extends `${string}:${infer Param}/${infer Rest}`
+  ? Param | UrlParamNames<`/${Rest}`>
+  : Url extends `${string}:${infer Param}`
+    ? Param
+    : never
+
+export type UrlParams<Url extends UrlOptions<string, never>> = Url extends (params: infer P) => string
+  ? P
+  : Url extends string
+    ? Record<UrlParamNames<Url>, string | undefined>
+    : never
+
+/** Recursive tree structure of endpoint definitions, used as input to `createEndpoints`. */
+export type Endpoints = {
+  // oxlint-disable-next-line typescript/no-explicit-any
+  [entity: string]: Endpoints | QueryEndpoint<any, any, any, any, any> | MutationEndpoint<any, any, any>
+}
+
+/**
+ * The output of `createEndpoints`. Recursively prepends each nesting key to every endpoint's
+ * query key, so that `endpoints.company.process(...)` produces a query key like
+ * `['company', 'process', ...params]`. Each node also carries an `$invalidateKey` for
+ * partial cache invalidation (e.g. invalidate all `['company']` queries).
+ */
+export type MappedEndpoints<T extends Endpoints, Path extends QueryKey = []> = { $invalidateKey: Path } & {
+  [K in keyof T]: T[K] extends Endpoints
+    ? MappedEndpoints<T[K], [...Path, K]>
+    : T[K] extends QueryEndpoint<infer QueryFnOutput, infer Params, infer Error, infer FnKey, infer Output>
+      ? FnKey extends QueryKey
+        ? QueryEndpoint<QueryFnOutput, Params, Error, [...Path, K, ...FnKey], Output> & { $invalidateKey: [...Path, K] }
+        : never
+      : T[K] extends MutationEndpoint
+        ? T[K]
+        : never;
+}
+
+export type EndpointParams<Params extends ApiParams> = MaybeParams<
+  Params,
+  [ params: Params, options?: MaybeRef<RequestInit> ]
+>
+
+/** Partial query options for an endpoint, useful for overriding specific options at the call site. */
+// oxlint-disable-next-line typescript/no-explicit-any
+export type PartialEndpointOptions<T extends (...args: never[]) => any> = Partial<ReturnType<T>>
+/** Full query options returned by calling an endpoint. */
+// oxlint-disable-next-line typescript/no-explicit-any
+export type EndpointOptions<T extends (...args: never[]) => any> = ReturnType<T>
+
+/**
+ * A callable endpoint definition. Call it with reactive params to get `QueryOptions`
+ * that can be spread into `useQuery`.
+ *
+ * @typeParam QueryFnOutput - Raw data type returned by the fetch (`TQueryFnData`)
+ * @typeParam Params - The path/query/body parameter bag
+ * @typeParam Key - The query key tuple (auto-generated from params and nesting path)
+ * @typeParam Output - Transformed data type after `select` (`TData`), defaults to `QueryFnOutput`
+ *
+ * @example
+ * // Spread into useQuery
+ * useQuery({ ...endpoints.company.process({ params: { processId } }) })
+ *
+ * // Imperative fetch via toFetchOptions
+ * queryClient.fetchQuery(toFetchOptions(endpoints.company.process({ params: { processId: 1 } })))
+ */
+export interface QueryEndpoint<
+  QueryFnOutput,
+  Params extends ApiParams,
+  Error = DefaultError,
+  Key extends QueryKey = QueryKey,
+  Output = QueryFnOutput,
+> {
+  <OverriddenQueryFnOutput extends QueryFnOutput = QueryFnOutput,
+    OverriddenError extends Error = Error,
+  >(
+    ...rest: EndpointParams<Params>
+  ): QueryOptions<
+    OverriddenQueryFnOutput,
+    OverriddenError, Key,
+    [Output] extends [QueryFnOutput] ? OverriddenQueryFnOutput : Output
+  > & {
+    $invalidateKey: Key
+  }
+  /** @internal phantom type for output type extraction via `EndpointOutput` - not set at runtime */
+  $output?: QueryFnOutput
+  $brand: 'QueryEndpoint'
+};
+
+/**
+ * A callable endpoint definition. Call it with reactive params to get `QueryOptions`
+ * that can be spread into `useQuery`.
+ *
+ * @typeParam QueryFnOutput - Raw data type returned by the fetch (`TQueryFnData`)
+ * @typeParam Params - The path/query/body parameter bag
+ * @typeParam Key - The query key tuple (auto-generated from params and nesting path)
+ * @typeParam Output - Transformed data type after `select` (`TData`), defaults to `QueryFnOutput`
+ *
+ * @example
+ * // Spread into useQuery
+ * useQuery({ ...endpoints.company.process({ params: { processId } }) })
+ *
+ * // Imperative fetch via toFetchOptions
+ * queryClient.fetchQuery(toFetchOptions(endpoints.company.process({ params: { processId: 1 } })))
+ */
+export interface MutationEndpoint<
+  Data = unknown,
+  Variables = unknown,
+  Error = DefaultError,
+> {
+  <OverriddenData extends Data = Data,
+    OverriddenError extends Error = Error,
+    OverriddenVariables extends Variables = Variables,
+  >(options?: MaybeRef<RequestInit>): MutationOptions<
+    OverriddenData,
+    OverriddenError,
+    OverriddenVariables
+  >
+  /** @internal phantom type for output type extraction via `EndpointOutput` - not set at runtime */
+  $output?: Data
+  $brand: 'MutationEndpoint'
+};
+
+export type MutateInput<
+  Variables,
+  Params extends ApiMutationParams,
+> = {
+  body: Variables
+} & Params
+
+/**
+ * A covariant-safe version of `Endpoint` for use in function parameter positions where
+ * the output type needs to be constrained (e.g. `useCachedBulkOperation`).
+ * Uses `out` variance annotation and widens callback-typed properties (`enabled`, `staleTime`)
+ * to avoid contravariance issues.
+ */
+export interface LossyCovariantEndpoint<
+  out QueryFnOutput,
+  Params extends ApiParams,
+  Error = DefaultError,
+  Key extends QueryKey = QueryKey,
+  Output = QueryFnOutput,
+> {
+  <OverriddenQueryFnOutput extends QueryFnOutput = QueryFnOutput,
+    OverriddenError extends Error = Error>(
+    ...rest: EndpointParams<Params>
+  ): LossyCovariantQueryOptions<
+    OverriddenQueryFnOutput,
+    OverriddenError, Key,
+    [Output] extends [QueryFnOutput] ? OverriddenQueryFnOutput : Output
+  > & {
+    $invalidateKey: Key
+  }
+  /** @internal phantom type for output type extraction via `EndpointOutput` - not set at runtime */
+  $output?: QueryFnOutput
+}
+
+/** Extracts the raw output type (`QueryFnOutput`) from an endpoint via its phantom `$output` field. */
+
+export type EndpointOutput<
+  // oxlint-disable-next-line typescript/no-explicit-any
+  T extends QueryEndpoint<any, any, any, any, any> | LossyCovariantEndpoint<any, any, any, any, any>,
+> = NonNullable<T['$output']>
+
+export type UrlOptions<T extends string, Params extends ParamsBase> = T | ((params: Params) => T)
+
+export type QueryParamsFn<Params extends ApiParams<ParamsBase, ParamsBase, unknown>> = (
+  params: Params,
+) => ApiParams<ParamsBase, ParamsBase, unknown>

--- a/packages/operations/src/unwrapParams.ts
+++ b/packages/operations/src/unwrapParams.ts
@@ -1,0 +1,23 @@
+import { mapValues } from 'lodash-es';
+import { type MaybeRef, unref } from 'vue';
+
+/**
+ * Deeply unwraps an API params bag. Each section (`params`/`queryParams`/`body`) may be a
+ * ref/computed, and so may each of a section's properties. This returns plain values so
+ * `paramsFn` transforms never have to deal with refs/computed when reading or spreading.
+ */
+export function deepUnwrapParams<T>(
+  bag: MaybeRef<T> | undefined,
+): T {
+  return mapValues(
+    (unref(bag) ?? {}) as Record<string, unknown>,
+    (section) => {
+      const unrefedSection = unref(section);
+      return unrefedSection !== null
+        && typeof unrefedSection === 'object'
+        && !Array.isArray(unrefedSection)
+        ? mapValues(unrefedSection, v => unref(v))
+        : unrefedSection;
+    },
+  ) as T;
+}

--- a/packages/operations/tsconfig.json
+++ b/packages/operations/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "verbatimModuleSyntax": true,
+    "types": [
+      "vite/client"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/operations/vite.config.js
+++ b/packages/operations/vite.config.js
@@ -1,0 +1,39 @@
+import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+import pkg from './package.json'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    dts({
+      staticImport: true,
+    }),
+  ],
+  build: {
+    emptyOutDir: false,
+    lib: {
+      formats: ['es'],
+      // Could also be a dictionary or array of multiple entry points
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+      },
+    },
+    rollupOptions: {
+      // make sure to externalize deps that shouldn't be bundled
+      // into your library
+      external: [
+        ...Object.keys(pkg.dependencies ?? {}),
+        ...Object.keys(pkg.peerDependencies ?? {}),
+      ],
+      output: {
+        // Provide global variables to use in the UMD build
+        // for externalized deps
+        globals: {
+          vue: 'Vue',
+        },
+      },
+    },
+  },
+})

--- a/packages/operations/vitest.config.ts
+++ b/packages/operations/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@teamnovu/kit-cookieconsent':
         specifier: workspace:^
         version: link:packages/cookieconsent
+      '@teamnovu/kit-operations':
+        specifier: workspace:^
+        version: link:packages/operations
       '@teamnovu/kit-shopware-api-client':
         specifier: workspace:^
         version: link:packages/shopware-api-client
@@ -35,28 +38,28 @@ importers:
     devDependencies:
       '@eslint/compat':
         specifier: ^1.2.9
-        version: 1.2.9(eslint@9.25.0(jiti@2.4.2))
+        version: 1.2.9(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
       '@eslint/js':
         specifier: ^9.25.0
         version: 9.25.0
       '@teamnovu/eslint-config-vue':
         specifier: ^9.0.13
-        version: 9.0.13(eslint@9.25.0(jiti@2.4.2))(tailwindcss@3.4.17)(typescript@5.8.3)
+        version: 9.0.13(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(tailwindcss@3.4.17)(typescript@5.8.3)
       '@types/lodash-es':
         specifier: ^4.17.6
         version: 4.17.12
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.30.1
-        version: 8.30.1(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
+        version: 8.30.1(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3)
       '@typescript-eslint/parser':
         specifier: ^7.0.2
-        version: 7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
+        version: 7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3)
       '@vitejs/plugin-vue':
         specifier: ^4.0.0
-        version: 4.6.2(vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))
+        version: 4.6.2(vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.25(typescript@5.8.3))
       '@vue/cli-service':
         specifier: ^5.0.8
-        version: 5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(vue@3.5.13(typescript@5.8.3))(webpack-sources@3.2.3)
+        version: 5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(supports-color@9.4.0)(vue@3.5.25(typescript@5.8.3))(webpack-sources@3.2.3)
       '@vue/compiler-sfc':
         specifier: ^3.2.47
         version: 3.5.13
@@ -68,13 +71,13 @@ importers:
         version: 7.6.0
       eslint:
         specifier: ^9.25.0
-        version: 9.25.0(jiti@2.4.2)
+        version: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       eslint-config-airbnb-base:
         specifier: ^15.0.0
-        version: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)))(eslint@9.25.0(jiti@2.4.2))
+        version: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0)))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
       eslint-plugin-vue:
         specifier: ^10.3.0
-        version: 10.3.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2))(vue-eslint-parser@9.4.3(eslint@9.25.0(jiti@2.4.2)))
+        version: 10.3.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(vue-eslint-parser@9.4.3(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0)))
       esno:
         specifier: ^0.16.3
         version: 0.16.3
@@ -104,19 +107,19 @@ importers:
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.30.1
-        version: 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
+        version: 8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)
       vite:
         specifier: ^6.3.0
         version: 6.3.0(@types/node@22.14.1)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
       vite-plugin-dts:
         specifier: ^4.5.3
-        version: 4.5.3(@types/node@22.14.1)(rollup@4.46.3)(typescript@5.8.3)(vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
+        version: 4.5.3(@types/node@22.14.1)(rollup@4.46.3)(supports-color@9.4.0)(typescript@5.8.3)(vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
       vitepress:
         specifier: ^1.0.0-alpha.72
         version: 1.6.3(@algolia/client-search@5.23.4)(@types/node@22.14.1)(change-case@5.4.4)(fuse.js@7.1.0)(jwt-decode@4.0.0)(postcss@8.4.35)(sass@1.86.3)(search-insights@2.17.3)(terser@5.39.0)(typescript@5.8.3)
       vitepress-plugin-search:
         specifier: ^1.0.4-alpha.19
-        version: 1.0.4-alpha.22(flexsearch@0.7.43)(vitepress@1.6.3(@algolia/client-search@5.23.4)(@types/node@22.14.1)(change-case@5.4.4)(fuse.js@7.1.0)(jwt-decode@4.0.0)(postcss@8.4.35)(sass@1.86.3)(search-insights@2.17.3)(terser@5.39.0)(typescript@5.8.3))(vue@3.5.13(typescript@5.8.3))
+        version: 1.0.4-alpha.22(flexsearch@0.7.43)(vitepress@1.6.3(@algolia/client-search@5.23.4)(@types/node@22.14.1)(change-case@5.4.4)(fuse.js@7.1.0)(jwt-decode@4.0.0)(postcss@8.4.35)(sass@1.86.3)(search-insights@2.17.3)(terser@5.39.0)(typescript@5.8.3))(vue@3.5.25(typescript@5.8.3))
 
   packages/animations:
     dependencies:
@@ -232,11 +235,33 @@ importers:
         version: link:../composables
       nuxt:
         specifier: ^3.0.0
-        version: 3.16.2(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(db0@0.3.1)(encoding@0.1.13)(eslint@9.25.0(jiti@2.4.2))(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.0)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.3)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(yaml@2.8.1)
+        version: 3.16.2(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(db0@0.3.1)(encoding@0.1.13)(eslint@9.25.0(jiti@2.4.2))(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.0)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.3)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(yaml@2.8.1)
     devDependencies:
       '@nuxt/schema':
         specifier: ^3.10.2
         version: 3.16.2
+
+  packages/operations:
+    dependencies:
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
+    devDependencies:
+      '@tanstack/vue-query':
+        specifier: ^5.101.0
+        version: 5.101.0(vue@3.5.25(typescript@5.9.2))
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.25(typescript@5.9.2))
+      '@vitest/ui':
+        specifier: ^2.0.0
+        version: 2.1.9(vitest@2.1.9)
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@12.10.3)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)
+      vue:
+        specifier: ^3.5.25
+        version: 3.5.25(typescript@5.9.2)
 
   packages/shopware-api-client:
     dependencies:
@@ -279,10 +304,10 @@ importers:
         version: 4.2.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.30.1
-        version: 8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
+        version: 8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2))(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: ^8.30.1
-        version: 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
+        version: 8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2)
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.6
@@ -291,19 +316,19 @@ importers:
         version: 9.25.0(jiti@2.4.2)
       eslint-import-resolver-typescript:
         specifier: ^4.3.3
-        version: 4.3.3(eslint-plugin-import@2.31.0)(eslint@9.25.0(jiti@2.4.2))
+        version: 4.3.3(eslint-plugin-import@2.31.0)(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-typescript@4.3.3)(eslint@9.25.0(jiti@2.4.2))
+        version: 2.31.0(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2))(eslint-import-resolver-typescript@4.3.3)(eslint@9.25.0(jiti@2.4.2))
       typescript-eslint:
         specifier: ^8.30.1
         version: 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
       unplugin-dts:
         specifier: ^1.0.0-beta.4
-        version: 1.0.0-beta.4(@microsoft/api-extractor@7.52.8(@types/node@24.3.0))(esbuild@0.25.2)(rollup@4.46.3)(typescript@5.9.2)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(webpack@5.90.3(esbuild@0.25.2))
+        version: 1.0.0-beta.4(@microsoft/api-extractor@7.52.8(@types/node@24.3.0))(esbuild@0.25.2)(rollup@4.46.3)(supports-color@9.4.0)(typescript@5.9.2)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(webpack@5.90.3(esbuild@0.25.2))
       vitest:
         specifier: ^3.1.2
-        version: 3.1.2(@types/node@24.3.0)(happy-dom@12.10.3)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
+        version: 3.1.2(@types/node@24.3.0)(happy-dom@12.10.3)(jiti@2.4.2)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
 
   packages/vue-forms:
     dependencies:
@@ -322,7 +347,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@5.4.18(@types/node@24.3.0)(sass@1.86.3)(terser@5.39.0))(vue@3.5.25(typescript@5.9.2))
+        version: 6.0.1(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.25(typescript@5.9.2))
       '@vitest/ui':
         specifier: ^2.0.0
         version: 2.1.9(vitest@2.1.9)
@@ -331,7 +356,7 @@ importers:
         version: 12.10.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@12.10.3)(sass@1.86.3)(terser@5.39.0)
+        version: 2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@12.10.3)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)
       vue:
         specifier: ^3.5.25
         version: 3.5.25(typescript@5.9.2)
@@ -1481,24 +1506,28 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.56.5':
     resolution: {integrity: sha512-SCIqrL5apVbrtMoqOpKX/Ez+c46WmW0Tyhtu+Xby281biH+wYu70m+fux9ZsGmbHc2ojd4FxUcaUdCZtb5uTOQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-x64-gnu@0.56.5':
     resolution: {integrity: sha512-I2mpX35NWo83hay4wrnzFLk3VuGK1BBwHaqvEdqsCode8iG8slYJRJPICVbCEWlkR3rotlTQ+608JcRU0VqZ5Q==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.56.5':
     resolution: {integrity: sha512-xfzUHGYOh3PGWZdBuY5r1czvE8EGWPAmhTWHqkw3/uAfUVWN/qrrLjMojiaiWyUgl/9XIFg05m5CJH9dnngh5Q==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-wasm32-wasi@0.56.5':
     resolution: {integrity: sha512-+z3Ofmc1v5kcu8fXgG5vn7T1f52P47ceTTmTXsm5HPY7rq5EMYRUaBnxH6cesXwY1OVVCwYlIZbCiy8Pm1w8zQ==}
@@ -1556,36 +1585,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.1':
     resolution: {integrity: sha512-RJxlQQLkaMMIuWRozy+z2vEqbaQlCuaCgVZIUCzQLYggY22LZbP5Y1+ia+FD724Ids9e+XIyOLXLrLgQSHIthw==}
@@ -1782,111 +1817,133 @@ packages:
     resolution: {integrity: sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.46.3':
     resolution: {integrity: sha512-byyflM+huiwHlKi7VHLAYTKr67X199+V+mt1iRgJenAI594vcmGGddWlu6eHujmcdl6TqSNnvqaXJqZdnEWRGA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.40.0':
     resolution: {integrity: sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.3':
     resolution: {integrity: sha512-aLm3NMIjr4Y9LklrH5cu7yybBqoVCdr4Nvnm8WB7PKCn34fMCGypVNpGK0JQWdPAzR/FnoEoFtlRqZbBBLhVoQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.40.0':
     resolution: {integrity: sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.46.3':
     resolution: {integrity: sha512-VtilE6eznJRDIoFOzaagQodUksTEfLIsvXymS+UdJiSXrPW7Ai+WG4uapAc3F7Hgs791TwdGh4xyOzbuzIZrnw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.40.0':
     resolution: {integrity: sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.46.3':
     resolution: {integrity: sha512-dG3JuS6+cRAL0GQ925Vppafi0qwZnkHdPeuZIxIPXqkCLP02l7ka+OCyBoDEv8S+nKHxfjvjW4OZ7hTdHkx8/w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.40.0':
     resolution: {integrity: sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.3':
     resolution: {integrity: sha512-iU8DxnxEKJptf8Vcx4XvAUdpkZfaz0KWfRrnIRrOndL0SvzEte+MTM7nDH4A2Now4FvTZ01yFAgj6TX/mZl8hQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.40.0':
     resolution: {integrity: sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.46.3':
     resolution: {integrity: sha512-VrQZp9tkk0yozJoQvQcqlWiqaPnLM6uY1qPYXvukKePb0fqaiQtOdMJSxNFUZFsGw5oA5vvVokjHrx8a9Qsz2A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.40.0':
     resolution: {integrity: sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.46.3':
     resolution: {integrity: sha512-uf2eucWSUb+M7b0poZ/08LsbcRgaDYL8NCGjUeFMwCWFwOuFcZ8D9ayPl25P3pl+D2FH45EbHdfyUesQ2Lt9wA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.40.0':
     resolution: {integrity: sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.46.3':
     resolution: {integrity: sha512-7tnUcDvN8DHm/9ra+/nF7lLzYHDeODKKKrh6JmZejbh1FnCNZS8zMkZY5J4sEipy2OW1d1Ncc4gNHUd0DLqkSg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.40.0':
     resolution: {integrity: sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.46.3':
     resolution: {integrity: sha512-MUpAOallJim8CsJK+4Lc9tQzlfPbHxWDrGXZm2z6biaadNpvh3a5ewcdat478W+tXDoUiHwErX/dOql7ETcLqg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.40.0':
     resolution: {integrity: sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.46.3':
     resolution: {integrity: sha512-F42IgZI4JicE2vM2PWCe0N5mR5vR0gIdORPqhGQ32/u1S1v3kLtbZ0C/mi9FFk7C5T0PgdeyWEPajPjaUpyoKg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.40.0':
     resolution: {integrity: sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.46.3':
     resolution: {integrity: sha512-oLc+JrwwvbimJUInzx56Q3ujL3Kkhxehg7O1gWAYzm8hImCd5ld1F2Gry5YDjR21MNb5WCKhC9hXgU7rRlyegQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.40.0':
     resolution: {integrity: sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==}
@@ -2041,8 +2098,20 @@ packages:
     resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
     engines: {node: '>=12'}
 
+  '@tanstack/query-core@5.101.0':
+    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+
   '@tanstack/query-core@5.85.3':
     resolution: {integrity: sha512-9Ne4USX83nHmRuEYs78LW+3lFEEO2hBDHu7mrdIgAFx5Zcrs7ker3n/i8p4kf6OgKExmaDN5oR0efRD7i2J0DQ==}
+
+  '@tanstack/vue-query@5.101.0':
+    resolution: {integrity: sha512-sZeW0RvfEZ9QRiaXirE/HQZsFT5saMlPZVfeYvjPX6lqSBS9lkD7wfnCfzOBns6HD2f34Gx9cazkuU3Xj6hl/A==}
+    peerDependencies:
+      '@vue/composition-api': ^1.1.2
+      vue: ^2.6.0 || ^3.3.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
 
   '@tanstack/vue-query@5.85.3':
     resolution: {integrity: sha512-SwLIgbHccHNdBTrL89n6DLtnpDO+pj4KQZUcv5YecZ+a/Bc9AIOcv7erqitbKiUXsBVCPdj4IagE0q1E+ha5oQ==}
@@ -2330,6 +2399,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/vue@2.0.6':
     resolution: {integrity: sha512-jx+4s/zHhqnE2aCI+sN2V52oZj/STzH00Q6N3OG8ha/RPtmZxeGGMaG5vC8PPV6Povv8tySZkQZQXctwss0JPw==}
@@ -2365,36 +2435,43 @@ packages:
     resolution: {integrity: sha512-cXiUMXZEgr0ZAa9af874VPME1q1Zalk9o5bsjMTZBfiV7Q/oQT7dX4VKCclEc95ympx8H3R8cYkbeySAIxvadQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.6.2':
     resolution: {integrity: sha512-9iwEHcepURA3c2GP74rEl7IdciGqzWzV5jSfjXtKyYfz7aAhTVZON3qdAt2r00uQYgLMf5ZDVsG/RvQbBOygbw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.6.2':
     resolution: {integrity: sha512-/LptGF05l0Ihpc1Fx7kbs0d9NAWp05cKLqYefi8xYnxuaoO7lTbxWJ2B60HGiU7oqn0rLmJG0ZgbwyZlVsVuGw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.6.2':
     resolution: {integrity: sha512-9og1+kOtdDGTWFAiqXSGyRTjYlGnM2BhNuRXKLFnbDvWe57LzokI3USbX4c3condKaoag2m74DbJHtPg5ZBTYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.6.2':
     resolution: {integrity: sha512-AZVlbIEg0+iNZ6ZJ0/OQtfCxZJZ3XUHdmOW5kWqTXeyONkO5Q9dYui37ui6a6cs/bsPsFDPiEkvmrVqNYhDX1w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.6.2':
     resolution: {integrity: sha512-kaFVj+mt3t7Y1W1SUFq1A30UCPg24w5pbnPKQ6rvNCyiBB91SzC1jrC64zldagBHlIP+suURfEvNNpMDo2IaBg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.6.2':
     resolution: {integrity: sha512-3rWsCizepV9mawiq5tjkA/5Z55m83L7KAK0QNIyiKd7hq71F7woCRkfr/LLsoRcM8E3ay1mWPYRCfFgMvC1i2A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.6.2':
     resolution: {integrity: sha512-/KeqvjCDPqhgSovlrAvuiSiExUj93w1QwSCU3aKlJ+cl03lLa4Pn/HgiGlsx+2BwT2JXIDBY0gbKW2jIDdpczg==}
@@ -4225,10 +4302,6 @@ packages:
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
-  enhanced-resolve@5.15.0:
-    resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
-    engines: {node: '>=10.13.0'}
-
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
     engines: {node: '>=10.13.0'}
@@ -4279,9 +4352,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@1.4.1:
-    resolution: {integrity: sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==}
 
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
@@ -4869,25 +4939,28 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -7705,10 +7778,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser-webpack-plugin@5.3.10:
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
@@ -8077,6 +8152,7 @@ packages:
 
   unplugin-vue-router@0.12.0:
     resolution: {integrity: sha512-xjgheKU0MegvXQcy62GVea0LjyOdMxN0/QH+ijN29W62ZlMhG7o7K+0AYqfpprvPwpWtuRjiyC5jnV2SxWye2w==}
+    deprecated: 'Merged into vuejs/router. Migrate: https://router.vuejs.org/guide/migration/v4-to-v5.html'
     peerDependencies:
       vue-router: ^4.4.0
     peerDependenciesMeta:
@@ -8207,6 +8283,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -8676,6 +8753,7 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -9013,18 +9091,18 @@ snapshots:
 
   '@babel/compat-data@7.26.8': {}
 
-  '@babel/core@7.26.10':
+  '@babel/core@7.26.10(supports-color@9.4.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.26.2
       '@babel/generator': 7.27.0
       '@babel/helper-compilation-targets': 7.27.0
-      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.10)
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.10(supports-color@9.4.0))
       '@babel/helpers': 7.27.0
-      '@babel/parser': 7.27.0
+      '@babel/parser': 7.28.5
       '@babel/template': 7.27.0
-      '@babel/traverse': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/traverse': 7.27.0(supports-color@9.4.0)
+      '@babel/types': 7.28.5
       convert-source-map: 2.0.0
       debug: 4.4.0(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
@@ -9035,15 +9113,15 @@ snapshots:
 
   '@babel/generator@7.27.0':
     dependencies:
-      '@babel/parser': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.25.9':
     dependencies:
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.5
 
   '@babel/helper-compilation-targets@7.23.6':
     dependencies:
@@ -9061,61 +9139,61 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.27.0(@babel/core@7.26.10)':
+  '@babel/helper-create-class-features-plugin@7.27.0(@babel/core@7.26.10(supports-color@9.4.0))':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.26.10(supports-color@9.4.0)
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.10)
+      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.10(supports-color@9.4.0))
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.27.0
+      '@babel/traverse': 7.27.0(supports-color@9.4.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
-      '@babel/traverse': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/traverse': 7.27.0(supports-color@9.4.0)
+      '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.25.9':
     dependencies:
-      '@babel/traverse': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/traverse': 7.27.0(supports-color@9.4.0)
+      '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.10)':
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.10(supports-color@9.4.0))':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.26.10(supports-color@9.4.0)
       '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.27.0
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.27.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.25.9':
     dependencies:
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.5
 
   '@babel/helper-plugin-utils@7.26.5': {}
 
-  '@babel/helper-replace-supers@7.26.5(@babel/core@7.26.10)':
+  '@babel/helper-replace-supers@7.26.5(@babel/core@7.26.10(supports-color@9.4.0))':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.26.10(supports-color@9.4.0)
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.27.0
+      '@babel/traverse': 7.27.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
-      '@babel/traverse': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/traverse': 7.27.0(supports-color@9.4.0)
+      '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -9134,7 +9212,7 @@ snapshots:
   '@babel/helpers@7.27.0':
     dependencies:
       '@babel/template': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.5
 
   '@babel/parser@7.27.0':
     dependencies:
@@ -9144,24 +9222,24 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
-  '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.10)':
+  '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.10(supports-color@9.4.0))':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.26.10(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.10)':
+  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.10(supports-color@9.4.0))':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.26.10(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-typescript@7.27.0(@babel/core@7.26.10)':
+  '@babel/plugin-transform-typescript@7.27.0(@babel/core@7.26.10(supports-color@9.4.0))':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.26.10(supports-color@9.4.0)
       '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-create-class-features-plugin': 7.27.0(@babel/core@7.26.10)
+      '@babel/helper-create-class-features-plugin': 7.27.0(@babel/core@7.26.10(supports-color@9.4.0))
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.10(supports-color@9.4.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9172,16 +9250,16 @@ snapshots:
   '@babel/template@7.27.0':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
 
-  '@babel/traverse@7.27.0':
+  '@babel/traverse@7.27.0(supports-color@9.4.0)':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/generator': 7.27.0
-      '@babel/parser': 7.27.0
+      '@babel/parser': 7.28.5
       '@babel/template': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.5
       debug: 4.4.0(supports-color@9.4.0)
       globals: 11.12.0
     transitivePeerDependencies:
@@ -9189,8 +9267,8 @@ snapshots:
 
   '@babel/types@7.26.9':
     dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.27.0':
     dependencies:
@@ -9540,6 +9618,11 @@ snapshots:
   '@esbuild/win32-x64@0.25.2':
     optional: true
 
+  '@eslint-community/eslint-utils@4.6.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))':
+    dependencies:
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.6.0(eslint@9.25.0(jiti@2.4.2))':
     dependencies:
       eslint: 9.25.0(jiti@2.4.2)
@@ -9547,11 +9630,11 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/compat@1.2.9(eslint@9.25.0(jiti@2.4.2))':
+  '@eslint/compat@1.2.9(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))':
     optionalDependencies:
-      eslint: 9.25.0(jiti@2.4.2)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
 
-  '@eslint/config-array@0.20.0':
+  '@eslint/config-array@0.20.0(supports-color@9.4.0)':
     dependencies:
       '@eslint/object-schema': 2.1.6
       debug: 4.4.0(supports-color@9.4.0)
@@ -9565,7 +9648,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1':
+  '@eslint/eslintrc@3.3.1(supports-color@9.4.0)':
     dependencies:
       ajv: 6.12.6
       debug: 4.4.0(supports-color@9.4.0)
@@ -9639,13 +9722,13 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.22
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -9671,14 +9754,14 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.22':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kwsites/file-exists@1.1.1':
+  '@kwsites/file-exists@1.1.1(supports-color@9.4.0)':
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
@@ -9688,10 +9771,10 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.4': {}
 
-  '@mapbox/node-pre-gyp@1.0.11(encoding@0.1.13)':
+  '@mapbox/node-pre-gyp@1.0.11(encoding@0.1.13)(supports-color@9.4.0)':
     dependencies:
       detect-libc: 2.0.3
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@9.4.0)
       make-dir: 3.1.0
       node-fetch: 2.7.0(encoding@0.1.13)
       nopt: 5.0.0
@@ -9801,15 +9884,15 @@ snapshots:
       uuid: 11.1.0
       write-file-atomic: 6.0.0
 
-  '@netlify/functions@3.1.0(encoding@0.1.13)(rollup@4.40.0)':
+  '@netlify/functions@3.1.0(encoding@0.1.13)(rollup@4.40.0)(supports-color@9.4.0)':
     dependencies:
       '@netlify/blobs': 8.2.0
       '@netlify/dev-utils': 1.1.0
       '@netlify/serverless-functions-api': 1.33.0
-      '@netlify/zip-it-and-ship-it': 9.43.1(encoding@0.1.13)(rollup@4.40.0)
+      '@netlify/zip-it-and-ship-it': 9.43.1(encoding@0.1.13)(rollup@4.40.0)(supports-color@9.4.0)
       cron-parser: 4.9.0
       decache: 4.6.2
-      extract-zip: 2.0.1
+      extract-zip: 2.0.1(supports-color@9.4.0)
       is-stream: 4.0.1
       jwt-decode: 4.0.0
       lambda-local: 2.2.0
@@ -9831,13 +9914,13 @@ snapshots:
 
   '@netlify/serverless-functions-api@1.37.0': {}
 
-  '@netlify/zip-it-and-ship-it@9.43.1(encoding@0.1.13)(rollup@4.40.0)':
+  '@netlify/zip-it-and-ship-it@9.43.1(encoding@0.1.13)(rollup@4.40.0)(supports-color@9.4.0)':
     dependencies:
-      '@babel/parser': 7.27.0
+      '@babel/parser': 7.28.5
       '@babel/types': 7.26.9
       '@netlify/binary-info': 1.0.0
       '@netlify/serverless-functions-api': 1.37.0
-      '@vercel/nft': 0.27.7(encoding@0.1.13)(rollup@4.40.0)
+      '@vercel/nft': 0.27.7(encoding@0.1.13)(rollup@4.40.0)(supports-color@9.4.0)
       archiver: 7.0.1
       common-path-prefix: 3.0.0
       cp-file: 10.0.0
@@ -9857,7 +9940,7 @@ snapshots:
       normalize-path: 3.0.0
       p-map: 7.0.3
       path-exists: 5.0.0
-      precinct: 11.0.5
+      precinct: 11.0.5(supports-color@9.4.0)
       require-package-name: 2.0.1
       resolve: 2.0.0-next.5
       semver: 7.7.1
@@ -9939,7 +10022,7 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.1
 
-  '@nuxt/devtools@2.4.0(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))':
+  '@nuxt/devtools@2.4.0(supports-color@9.4.0)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
       '@nuxt/devtools-kit': 2.4.0(magicast@0.3.5)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
       '@nuxt/devtools-wizard': 2.4.0
@@ -9965,12 +10048,12 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 2.1.0
       semver: 7.7.1
-      simple-git: 3.27.0
+      simple-git: 3.27.0(supports-color@9.4.0)
       sirv: 3.0.1
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.13
       vite: 6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
-      vite-plugin-inspect: 11.0.0(@nuxt/kit@3.16.2(magicast@0.3.5))(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
+      vite-plugin-inspect: 11.0.0(@nuxt/kit@3.16.2(magicast@0.3.5))(supports-color@9.4.0)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
       vite-plugin-vue-tracer: 0.1.3(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))
       which: 5.0.0
       ws: 8.18.1
@@ -10031,12 +10114,12 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/vite-builder@3.16.2(@types/node@24.3.0)(eslint@9.25.0(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.0)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))(yaml@2.8.1)':
+  '@nuxt/vite-builder@3.16.2(@types/node@24.3.0)(eslint@9.25.0(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.0)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 3.16.2(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.40.0)
       '@vitejs/plugin-vue': 5.2.3(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))
-      '@vitejs/plugin-vue-jsx': 4.1.2(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))
+      '@vitejs/plugin-vue-jsx': 4.1.2(supports-color@9.4.0)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))
       autoprefixer: 10.4.21(postcss@8.5.3)
       consola: 3.4.2
       cssnano: 7.0.6(postcss@8.5.3)
@@ -10063,7 +10146,7 @@ snapshots:
       unenv: 2.0.0-rc.15
       unplugin: 2.3.2
       vite: 6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
-      vite-node: 3.1.1(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
+      vite-node: 3.1.1(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
       vite-plugin-checker: 0.9.1(eslint@9.25.0(jiti@2.4.2))(optionator@0.9.4)(typescript@5.8.3)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
       vue: 3.5.13(typescript@5.8.3)
       vue-bundle-renderer: 2.1.1
@@ -10252,7 +10335,7 @@ snapshots:
       estree-walker: 2.0.2
       fdir: 6.4.4(picomatch@4.0.2)
       is-reference: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       picomatch: 4.0.2
     optionalDependencies:
       rollup: 4.40.0
@@ -10261,7 +10344,7 @@ snapshots:
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.40.0)
       estree-walker: 2.0.2
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.40.0
 
@@ -10284,7 +10367,7 @@ snapshots:
   '@rollup/plugin-replace@6.0.2(rollup@4.40.0)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.40.0)
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.40.0
 
@@ -10580,10 +10663,10 @@ snapshots:
 
   '@speed-highlight/core@1.2.7': {}
 
-  '@stylistic/eslint-plugin@2.13.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)':
+  '@stylistic/eslint-plugin@2.13.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
-      eslint: 9.25.0(jiti@2.4.2)
+      '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       eslint-visitor-keys: 4.2.0
       espree: 10.3.0
       estraverse: 5.3.0
@@ -10608,7 +10691,17 @@ snapshots:
     dependencies:
       remove-accents: 0.5.0
 
+  '@tanstack/query-core@5.101.0': {}
+
   '@tanstack/query-core@5.85.3': {}
+
+  '@tanstack/vue-query@5.101.0(vue@3.5.25(typescript@5.9.2))':
+    dependencies:
+      '@tanstack/match-sorter-utils': 8.19.4
+      '@tanstack/query-core': 5.101.0
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.25(typescript@5.9.2)
+      vue-demi: 0.14.10(vue@3.5.25(typescript@5.9.2))
 
   '@tanstack/vue-query@5.85.3(vue@3.5.13(typescript@5.9.2))':
     dependencies:
@@ -10618,14 +10711,14 @@ snapshots:
       vue: 3.5.13(typescript@5.9.2)
       vue-demi: 0.14.10(vue@3.5.13(typescript@5.9.2))
 
-  '@teamnovu/eslint-config-vue@9.0.13(eslint@9.25.0(jiti@2.4.2))(tailwindcss@3.4.17)(typescript@5.8.3)':
+  '@teamnovu/eslint-config-vue@9.0.13(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(tailwindcss@3.4.17)(typescript@5.8.3)':
     dependencies:
-      '@stylistic/eslint-plugin': 2.13.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
-      eslint: 9.25.0(jiti@2.4.2)
-      eslint-plugin-readable-tailwind: 1.9.1(eslint@9.25.0(jiti@2.4.2))(tailwindcss@3.4.17)
+      '@stylistic/eslint-plugin': 2.13.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
+      eslint-plugin-readable-tailwind: 1.9.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(tailwindcss@3.4.17)
       eslint-plugin-tailwindcss: 3.18.0(tailwindcss@3.4.17)
-      eslint-plugin-vue: 9.33.0(eslint@9.25.0(jiti@2.4.2))
-      eslint-plugin-vuejs-accessibility: 2.4.1(eslint@9.25.0(jiti@2.4.2))
+      eslint-plugin-vue: 9.33.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
+      eslint-plugin-vuejs-accessibility: 2.4.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
     transitivePeerDependencies:
       - supports-color
       - tailwindcss
@@ -10637,7 +10730,7 @@ snapshots:
     dependencies:
       minimatch: 9.0.5
       path-browserify: 1.0.1
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
 
   '@tybys/wasm-util@0.9.0':
     dependencies:
@@ -10667,11 +10760,11 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.2
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   '@types/eslint@8.56.2':
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.7': {}
@@ -10823,15 +10916,15 @@ snapshots:
       '@types/node': 18.19.86
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.30.1(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.30.1(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.30.1
-      '@typescript-eslint/type-utils': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.30.1
-      eslint: 9.25.0(jiti@2.4.2)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -10840,15 +10933,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.30.1
-      '@typescript-eslint/type-utils': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.30.1
-      eslint: 9.25.0(jiti@2.4.2)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -10857,10 +10950,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2))(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.30.1
       '@typescript-eslint/type-utils': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
       '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
@@ -10874,36 +10967,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)':
+  '@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(supports-color@9.4.0)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.0(supports-color@9.4.0)
-      eslint: 9.25.0(jiti@2.4.2)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.30.1
       '@typescript-eslint/types': 8.30.1
       '@typescript-eslint/typescript-estree': 8.30.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.30.1
       debug: 4.4.0(supports-color@9.4.0)
-      eslint: 9.25.0(jiti@2.4.2)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)':
+  '@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.30.1
       '@typescript-eslint/types': 8.30.1
-      '@typescript-eslint/typescript-estree': 8.30.1(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.30.1(supports-color@9.4.0)(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.30.1
       debug: 4.4.0(supports-color@9.4.0)
       eslint: 9.25.0(jiti@2.4.2)
@@ -10921,12 +11014,12 @@ snapshots:
       '@typescript-eslint/types': 8.30.1
       '@typescript-eslint/visitor-keys': 8.30.1
 
-  '@typescript-eslint/type-utils@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.30.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)
       debug: 4.4.0(supports-color@9.4.0)
-      eslint: 9.25.0(jiti@2.4.2)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -10934,7 +11027,7 @@ snapshots:
 
   '@typescript-eslint/type-utils@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.30.1(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.30.1(supports-color@9.4.0)(typescript@5.9.2)
       '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
       debug: 4.4.0(supports-color@9.4.0)
       eslint: 9.25.0(jiti@2.4.2)
@@ -10949,7 +11042,7 @@ snapshots:
 
   '@typescript-eslint/types@8.30.1': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@5.62.0(supports-color@9.4.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -10963,7 +11056,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@7.18.0(supports-color@9.4.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -10975,6 +11068,20 @@ snapshots:
       ts-api-utils: 1.4.3(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.30.1(supports-color@9.4.0)(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.30.1
+      '@typescript-eslint/visitor-keys': 8.30.1
+      debug: 4.4.0(supports-color@9.4.0)
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10992,27 +11099,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.30.1(typescript@5.9.2)':
+  '@typescript-eslint/utils@8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/types': 8.30.1
-      '@typescript-eslint/visitor-keys': 8.30.1
-      debug: 4.4.0(supports-color@9.4.0)
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.7.1
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.6.0(eslint@9.25.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.6.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
       '@typescript-eslint/scope-manager': 8.30.1
       '@typescript-eslint/types': 8.30.1
       '@typescript-eslint/typescript-estree': 8.30.1(typescript@5.8.3)
-      eslint: 9.25.0(jiti@2.4.2)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -11022,7 +11115,7 @@ snapshots:
       '@eslint-community/eslint-utils': 4.6.0(eslint@9.25.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.30.1
       '@typescript-eslint/types': 8.30.1
-      '@typescript-eslint/typescript-estree': 8.30.1(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.30.1(supports-color@9.4.0)(typescript@5.9.2)
       eslint: 9.25.0(jiti@2.4.2)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -11101,9 +11194,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.6.2':
     optional: true
 
-  '@vercel/nft@0.27.7(encoding@0.1.13)(rollup@4.40.0)':
+  '@vercel/nft@0.27.7(encoding@0.1.13)(rollup@4.40.0)(supports-color@9.4.0)':
     dependencies:
-      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)
+      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)(supports-color@9.4.0)
       '@rollup/pluginutils': 5.1.4(rollup@4.40.0)
       acorn: 8.14.1
       acorn-import-attributes: 1.9.5(acorn@8.14.1)
@@ -11139,20 +11232,20 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.1.2(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))':
+  '@vitejs/plugin-vue-jsx@4.1.2(supports-color@9.4.0)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
-      '@babel/core': 7.26.10
-      '@babel/plugin-transform-typescript': 7.27.0(@babel/core@7.26.10)
-      '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.26.10)
+      '@babel/core': 7.26.10(supports-color@9.4.0)
+      '@babel/plugin-transform-typescript': 7.27.0(@babel/core@7.26.10(supports-color@9.4.0))
+      '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.26.10(supports-color@9.4.0))
       vite: 6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
       vue: 3.5.13(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@4.6.2(vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))':
+  '@vitejs/plugin-vue@4.6.2(vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.25(typescript@5.8.3))':
     dependencies:
       vite: 6.3.0(@types/node@22.14.1)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
-      vue: 3.5.13(typescript@5.8.3)
+      vue: 3.5.25(typescript@5.8.3)
 
   '@vitejs/plugin-vue@5.2.3(vite@5.4.18(@types/node@22.14.1)(sass@1.86.3)(terser@5.39.0))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
@@ -11164,10 +11257,10 @@ snapshots:
       vite: 6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
       vue: 3.5.13(typescript@5.8.3)
 
-  '@vitejs/plugin-vue@6.0.1(vite@5.4.18(@types/node@24.3.0)(sass@1.86.3)(terser@5.39.0))(vue@3.5.25(typescript@5.9.2))':
+  '@vitejs/plugin-vue@6.0.1(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.25(typescript@5.9.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 5.4.18(@types/node@24.3.0)(sass@1.86.3)(terser@5.39.0)
+      vite: 6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
       vue: 3.5.25(typescript@5.9.2)
 
   '@vitest/expect@2.1.9':
@@ -11188,7 +11281,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       vite: 5.4.18(@types/node@24.3.0)(sass@1.86.3)(terser@5.39.0)
 
@@ -11196,7 +11289,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.1.2
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       vite: 6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
 
@@ -11221,13 +11314,13 @@ snapshots:
   '@vitest/snapshot@2.1.9':
     dependencies:
       '@vitest/pretty-format': 2.1.9
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 1.1.2
 
   '@vitest/snapshot@3.1.2':
     dependencies:
       '@vitest/pretty-format': 3.1.2
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/spy@2.1.9':
@@ -11245,9 +11338,9 @@ snapshots:
       flatted: 3.3.3
       pathe: 1.1.2
       sirv: 3.0.1
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@12.10.3)(sass@1.86.3)(terser@5.39.0)
+      vitest: 2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@12.10.3)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -11287,7 +11380,7 @@ snapshots:
 
   '@vue-macros/common@1.16.1(vue@3.5.13(typescript@5.8.3))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.13
+      '@vue/compiler-sfc': 3.5.25
       ast-kit: 1.4.2
       local-pkg: 1.1.1
       magic-string-ast: 0.7.1
@@ -11298,55 +11391,55 @@ snapshots:
 
   '@vue/babel-helper-vue-transform-on@1.4.0': {}
 
-  '@vue/babel-plugin-jsx@1.4.0(@babel/core@7.26.10)':
+  '@vue/babel-plugin-jsx@1.4.0(@babel/core@7.26.10(supports-color@9.4.0))':
     dependencies:
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.10(supports-color@9.4.0))
       '@babel/template': 7.27.0
-      '@babel/traverse': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/traverse': 7.27.0(supports-color@9.4.0)
+      '@babel/types': 7.28.5
       '@vue/babel-helper-vue-transform-on': 1.4.0
-      '@vue/babel-plugin-resolve-type': 1.4.0(@babel/core@7.26.10)
-      '@vue/shared': 3.5.13
+      '@vue/babel-plugin-resolve-type': 1.4.0(@babel/core@7.26.10(supports-color@9.4.0))
+      '@vue/shared': 3.5.25
     optionalDependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.26.10(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/babel-plugin-resolve-type@1.4.0(@babel/core@7.26.10)':
+  '@vue/babel-plugin-resolve-type@1.4.0(@babel/core@7.26.10(supports-color@9.4.0))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/core': 7.26.10
+      '@babel/core': 7.26.10(supports-color@9.4.0)
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/parser': 7.27.0
-      '@vue/compiler-sfc': 3.5.13
+      '@babel/parser': 7.28.5
+      '@vue/compiler-sfc': 3.5.25
     transitivePeerDependencies:
       - supports-color
 
   '@vue/cli-overlay@5.0.8': {}
 
-  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(vue@3.5.13(typescript@5.8.3))(webpack-sources@3.2.3))(encoding@0.1.13)':
+  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(supports-color@9.4.0)(vue@3.5.25(typescript@5.8.3))(webpack-sources@3.2.3))(encoding@0.1.13)':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(vue@3.5.13(typescript@5.8.3))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(supports-color@9.4.0)(vue@3.5.25(typescript@5.8.3))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
-  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(vue@3.5.13(typescript@5.8.3))(webpack-sources@3.2.3))':
+  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(supports-color@9.4.0)(vue@3.5.25(typescript@5.8.3))(webpack-sources@3.2.3))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(vue@3.5.13(typescript@5.8.3))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(supports-color@9.4.0)(vue@3.5.25(typescript@5.8.3))(webpack-sources@3.2.3)
 
-  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(vue@3.5.13(typescript@5.8.3))(webpack-sources@3.2.3)':
+  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(supports-color@9.4.0)(vue@3.5.25(typescript@5.8.3))(webpack-sources@3.2.3)':
     dependencies:
       '@babel/helper-compilation-targets': 7.23.6
       '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.90.3)
       '@soda/get-current-script': 1.0.2
       '@types/minimist': 1.2.5
       '@vue/cli-overlay': 5.0.8
-      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(vue@3.5.13(typescript@5.8.3))(webpack-sources@3.2.3))(encoding@0.1.13)
-      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(vue@3.5.13(typescript@5.8.3))(webpack-sources@3.2.3))
+      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(supports-color@9.4.0)(vue@3.5.25(typescript@5.8.3))(webpack-sources@3.2.3))(encoding@0.1.13)
+      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(encoding@0.1.13)(lodash@4.17.21)(supports-color@9.4.0)(vue@3.5.25(typescript@5.8.3))(webpack-sources@3.2.3))
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)
       '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.5.13)(css-loader@6.10.0(webpack@5.90.3))(lodash@4.17.21)(webpack@5.90.3)
@@ -11386,12 +11479,12 @@ snapshots:
       ssri: 8.0.1
       terser-webpack-plugin: 5.3.10(webpack@5.90.3)
       thread-loader: 3.0.4(webpack@5.90.3)
-      vue-loader: 17.4.2(@vue/compiler-sfc@3.5.13)(vue@3.5.13(typescript@5.8.3))(webpack@5.90.3)
+      vue-loader: 17.4.2(@vue/compiler-sfc@3.5.13)(vue@3.5.25(typescript@5.8.3))(webpack@5.90.3)
       vue-style-loader: 4.1.3
       webpack: 5.90.3
       webpack-bundle-analyzer: 4.10.1
       webpack-chain: 6.5.1
-      webpack-dev-server: 4.15.1(debug@4.3.4)(webpack@5.90.3)
+      webpack-dev-server: 4.15.1(debug@4.3.4)(supports-color@9.4.0)(webpack@5.90.3)
       webpack-merge: 5.10.0
       webpack-virtual-modules: 0.4.6
       whatwg-fetch: 3.6.20
@@ -11945,9 +12038,9 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-import-assertions@1.9.0(acorn@8.11.3):
+  acorn-import-assertions@1.9.0(acorn@8.14.1):
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.14.1
 
   acorn-import-attributes@1.9.5(acorn@8.14.1):
     dependencies:
@@ -11965,7 +12058,7 @@ snapshots:
 
   address@1.2.2: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@9.4.0):
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
@@ -12175,14 +12268,14 @@ snapshots:
 
   ast-kit@1.4.2:
     dependencies:
-      '@babel/parser': 7.27.0
+      '@babel/parser': 7.28.5
       pathe: 2.0.3
 
   ast-module-types@5.0.0: {}
 
   ast-walker-scope@0.6.2:
     dependencies:
-      '@babel/parser': 7.27.0
+      '@babel/parser': 7.28.5
       ast-kit: 1.4.2
 
   async-function@1.0.0: {}
@@ -12438,7 +12531,7 @@ snapshots:
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
@@ -13032,9 +13125,9 @@ snapshots:
 
   detective-stylus@4.0.0: {}
 
-  detective-typescript@11.2.0:
+  detective-typescript@11.2.0(supports-color@9.4.0):
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@9.4.0)(typescript@5.8.3)
       ast-module-types: 5.0.0
       node-source-walk: 6.0.2
       typescript: 5.8.3
@@ -13168,11 +13261,6 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.15.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.2.1
-
   enhanced-resolve@5.18.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -13303,8 +13391,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-module-lexer@1.4.1: {}
 
   es-module-lexer@1.6.0: {}
 
@@ -13464,11 +13550,11 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)))(eslint@9.25.0(jiti@2.4.2)):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0)))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0)):
     dependencies:
       confusing-browser-globals: 1.0.11
-      eslint: 9.25.0(jiti@2.4.2)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2))
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
       object.assign: 4.1.5
       object.entries: 1.1.7
       semver: 6.3.1
@@ -13481,7 +13567,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.3.3(eslint-plugin-import@2.31.0)(eslint@9.25.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@4.3.3(eslint-plugin-import@2.31.0)(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0):
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
       eslint: 9.25.0(jiti@2.4.2)
@@ -13491,32 +13577,32 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.6.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-typescript@4.3.3)(eslint@9.25.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2))(eslint-import-resolver-typescript@4.3.3)(eslint@9.25.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.25.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
-      eslint: 9.25.0(jiti@2.4.2)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.3(eslint-plugin-import@2.31.0)(eslint@9.25.0(jiti@2.4.2)))(eslint@9.25.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.3)(eslint@9.25.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2)
       eslint: 9.25.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.3.3(eslint-plugin-import@2.31.0)(eslint@9.25.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 4.3.3(eslint-plugin-import@2.31.0)(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -13525,9 +13611,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.25.0(jiti@2.4.2)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.25.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13539,13 +13625,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-typescript@4.3.3)(eslint@9.25.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2))(eslint-import-resolver-typescript@4.3.3)(eslint@9.25.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -13556,7 +13642,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.25.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.3(eslint-plugin-import@2.31.0)(eslint@9.25.0(jiti@2.4.2)))(eslint@9.25.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.3)(eslint@9.25.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13568,15 +13654,15 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-readable-tailwind@1.9.1(eslint@9.25.0(jiti@2.4.2))(tailwindcss@3.4.17):
+  eslint-plugin-readable-tailwind@1.9.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(tailwindcss@3.4.17):
     dependencies:
-      eslint: 9.25.0(jiti@2.4.2)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       tailwindcss: 3.4.17
 
   eslint-plugin-tailwindcss@3.18.0(tailwindcss@3.4.17):
@@ -13585,39 +13671,39 @@ snapshots:
       postcss: 8.5.3
       tailwindcss: 3.4.17
 
-  eslint-plugin-vue@10.3.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2))(vue-eslint-parser@9.4.3(eslint@9.25.0(jiti@2.4.2))):
+  eslint-plugin-vue@10.3.0(@typescript-eslint/parser@7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(vue-eslint-parser@9.4.3(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.0(eslint@9.25.0(jiti@2.4.2))
-      eslint: 9.25.0(jiti@2.4.2)
+      '@eslint-community/eslint-utils': 4.6.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.7.1
-      vue-eslint-parser: 9.4.3(eslint@9.25.0(jiti@2.4.2))
+      vue-eslint-parser: 9.4.3(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.8.3)
 
-  eslint-plugin-vue@9.33.0(eslint@9.25.0(jiti@2.4.2)):
+  eslint-plugin-vue@9.33.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.0(eslint@9.25.0(jiti@2.4.2))
-      eslint: 9.25.0(jiti@2.4.2)
+      '@eslint-community/eslint-utils': 4.6.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       globals: 13.24.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.7.1
-      vue-eslint-parser: 9.4.3(eslint@9.25.0(jiti@2.4.2))
+      vue-eslint-parser: 9.4.3(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-vuejs-accessibility@2.4.1(eslint@9.25.0(jiti@2.4.2)):
+  eslint-plugin-vuejs-accessibility@2.4.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0)):
     dependencies:
       aria-query: 5.3.2
       emoji-regex: 10.4.0
-      eslint: 9.25.0(jiti@2.4.2)
-      vue-eslint-parser: 9.4.3(eslint@9.25.0(jiti@2.4.2))
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
+      vue-eslint-parser: 9.4.3(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -13644,10 +13730,52 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.6.0(eslint@9.25.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.20.0
+      '@eslint/config-array': 0.20.0(supports-color@9.4.0)
       '@eslint/config-helpers': 0.2.1
       '@eslint/core': 0.13.0
-      '@eslint/eslintrc': 3.3.1
+      '@eslint/eslintrc': 3.3.1(supports-color@9.4.0)
+      '@eslint/js': 9.25.0
+      '@eslint/plugin-kit': 0.2.8
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.2
+      '@types/estree': 1.0.7
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.0(supports-color@9.4.0)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.3.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.6.0(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.20.0(supports-color@9.4.0)
+      '@eslint/config-helpers': 0.2.1
+      '@eslint/core': 0.13.0
+      '@eslint/eslintrc': 3.3.1(supports-color@9.4.0)
       '@eslint/js': 9.25.0
       '@eslint/plugin-kit': 0.2.8
       '@humanfs/node': 0.16.6
@@ -13823,7 +13951,7 @@ snapshots:
       pathe: 1.1.2
       ufo: 1.6.1
 
-  extract-zip@2.0.1:
+  extract-zip@2.0.1(supports-color@9.4.0):
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
       get-stream: 5.2.0
@@ -14426,9 +14554,9 @@ snapshots:
 
   http-shutdown@1.2.2: {}
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@9.4.0):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@9.4.0)
       debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
@@ -15054,7 +15182,7 @@ snapshots:
 
   magic-string-ast@0.7.1:
     dependencies:
-      magic-string: 0.30.17
+      magic-string: 0.30.21
 
   magic-string@0.30.17:
     dependencies:
@@ -15066,8 +15194,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
       source-map-js: 1.2.1
 
   make-dir@3.1.0:
@@ -15314,10 +15442,10 @@ snapshots:
 
   nice-try@1.0.5: {}
 
-  nitropack@2.11.9(@netlify/blobs@8.2.0)(encoding@0.1.13):
+  nitropack@2.11.9(@netlify/blobs@8.2.0)(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
-      '@netlify/functions': 3.1.0(encoding@0.1.13)(rollup@4.40.0)
+      '@netlify/functions': 3.1.0(encoding@0.1.13)(rollup@4.40.0)(supports-color@9.4.0)
       '@rollup/plugin-alias': 5.1.1(rollup@4.40.0)
       '@rollup/plugin-commonjs': 28.0.3(rollup@4.40.0)
       '@rollup/plugin-inject': 5.0.5(rollup@4.40.0)
@@ -15372,7 +15500,7 @@ snapshots:
       scule: 1.3.0
       semver: 7.7.1
       serve-placeholder: 2.0.2
-      serve-static: 2.2.0
+      serve-static: 2.2.0(supports-color@9.4.0)
       source-map: 0.7.4
       std-env: 3.9.0
       ufo: 1.6.1
@@ -15449,7 +15577,7 @@ snapshots:
 
   node-source-walk@6.0.2:
     dependencies:
-      '@babel/parser': 7.27.0
+      '@babel/parser': 7.28.5
 
   nopt@5.0.0:
     dependencies:
@@ -15514,15 +15642,15 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@3.16.2(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(db0@0.3.1)(encoding@0.1.13)(eslint@9.25.0(jiti@2.4.2))(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.0)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.3)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(yaml@2.8.1):
+  nuxt@3.16.2(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(db0@0.3.1)(encoding@0.1.13)(eslint@9.25.0(jiti@2.4.2))(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.0)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.3)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(yaml@2.8.1):
     dependencies:
       '@nuxt/cli': 3.24.1(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 2.4.0(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))
+      '@nuxt/devtools': 2.4.0(supports-color@9.4.0)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(vue@3.5.13(typescript@5.8.3))
       '@nuxt/kit': 3.16.2(magicast@0.3.5)
       '@nuxt/schema': 3.16.2
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 3.16.2(@types/node@24.3.0)(eslint@9.25.0(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.0)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))(yaml@2.8.1)
+      '@nuxt/vite-builder': 3.16.2(@types/node@24.3.0)(eslint@9.25.0(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.0)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))(yaml@2.8.1)
       '@oxc-parser/wasm': 0.60.0
       '@unhead/vue': 2.0.6(vue@3.5.13(typescript@5.8.3))
       '@vue/shared': 3.5.13
@@ -15551,7 +15679,7 @@ snapshots:
       mlly: 1.7.4
       mocked-exports: 0.1.1
       nanotar: 0.2.0
-      nitropack: 2.11.9(@netlify/blobs@8.2.0)(encoding@0.1.13)
+      nitropack: 2.11.9(@netlify/blobs@8.2.0)(encoding@0.1.13)(supports-color@9.4.0)
       nypm: 0.6.0
       ofetch: 1.4.1
       ohash: 2.0.11
@@ -16381,7 +16509,7 @@ snapshots:
 
   preact@10.26.5: {}
 
-  precinct@11.0.5:
+  precinct@11.0.5(supports-color@9.4.0):
     dependencies:
       '@dependents/detective-less': 4.1.0
       commander: 10.0.1
@@ -16392,7 +16520,7 @@ snapshots:
       detective-sass: 5.0.3
       detective-scss: 4.0.3
       detective-stylus: 4.0.0
-      detective-typescript: 11.2.0
+      detective-typescript: 11.2.0(supports-color@9.4.0)
       module-definition: 5.0.1
       node-source-walk: 6.0.2
     transitivePeerDependencies:
@@ -16835,7 +16963,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.0:
+  send@1.2.0(supports-color@9.4.0):
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
       encodeurl: 2.0.0
@@ -16880,12 +17008,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.0:
+  serve-static@2.2.0(supports-color@9.4.0):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.0
+      send: 1.2.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17002,9 +17130,9 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-git@3.27.0:
+  simple-git@3.27.0(supports-color@9.4.0):
     dependencies:
-      '@kwsites/file-exists': 1.1.1
+      '@kwsites/file-exists': 1.1.1(supports-color@9.4.0)
       '@kwsites/promise-deferred': 1.1.1
       debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
@@ -17071,7 +17199,7 @@ snapshots:
 
   spdx-license-ids@3.0.17: {}
 
-  spdy-transport@3.0.0:
+  spdy-transport@3.0.0(supports-color@9.4.0):
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
       detect-node: 2.1.0
@@ -17082,13 +17210,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy@4.0.2:
+  spdy@4.0.2(supports-color@9.4.0):
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
-      spdy-transport: 3.0.0
+      spdy-transport: 3.0.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17589,20 +17717,20 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3):
+  typescript-eslint@8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.8.3)
-      eslint: 9.25.0(jiti@2.4.2)
+      '@typescript-eslint/eslint-plugin': 8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3))(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0))(typescript@5.8.3)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
   typescript-eslint@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
-      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2))(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.30.1(eslint@9.25.0(jiti@2.4.2))(supports-color@9.4.0)(typescript@5.9.2)
       '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.9.2)
       eslint: 9.25.0(jiti@2.4.2)
       typescript: 5.9.2
@@ -17691,14 +17819,14 @@ snapshots:
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       local-pkg: 1.1.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       mlly: 1.7.4
       pathe: 2.0.3
       picomatch: 4.0.2
       pkg-types: 2.1.0
       scule: 1.3.0
       strip-literal: 3.0.0
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
       unplugin: 2.3.2
       unplugin-utils: 0.2.4
 
@@ -17735,7 +17863,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-dts@1.0.0-beta.4(@microsoft/api-extractor@7.52.8(@types/node@24.3.0))(esbuild@0.25.2)(rollup@4.46.3)(typescript@5.9.2)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(webpack@5.90.3(esbuild@0.25.2)):
+  unplugin-dts@1.0.0-beta.4(@microsoft/api-extractor@7.52.8(@types/node@24.3.0))(esbuild@0.25.2)(rollup@4.46.3)(supports-color@9.4.0)(typescript@5.9.2)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))(webpack@5.90.3(esbuild@0.25.2)):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.46.3)
       '@volar/typescript': 2.4.20
@@ -17846,7 +17974,7 @@ snapshots:
   unwasm@0.3.9:
     dependencies:
       knitwork: 1.2.0
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       mlly: 1.7.4
       pathe: 1.1.2
       pkg-types: 1.3.1
@@ -17919,7 +18047,7 @@ snapshots:
     dependencies:
       vite: 6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
 
-  vite-node@2.1.9(@types/node@24.3.0)(sass@1.86.3)(terser@5.39.0):
+  vite-node@2.1.9(@types/node@24.3.0)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.4.0)
@@ -17937,7 +18065,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.1.1(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
+  vite-node@3.1.1(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.4.0)
@@ -17958,7 +18086,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.1.2(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
+  vite-node@3.1.2(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.4.0)
@@ -17988,7 +18116,7 @@ snapshots:
       picomatch: 4.0.2
       strip-ansi: 7.1.0
       tiny-invariant: 1.3.3
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
       vite: 6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
       vscode-uri: 3.1.0
     optionalDependencies:
@@ -17996,7 +18124,7 @@ snapshots:
       optionator: 0.9.4
       typescript: 5.8.3
 
-  vite-plugin-dts@4.5.3(@types/node@22.14.1)(rollup@4.46.3)(typescript@5.8.3)(vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)):
+  vite-plugin-dts@4.5.3(@types/node@22.14.1)(rollup@4.46.3)(supports-color@9.4.0)(typescript@5.8.3)(vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)):
     dependencies:
       '@microsoft/api-extractor': 7.52.3(@types/node@22.14.1)
       '@rollup/pluginutils': 5.1.4(rollup@4.46.3)
@@ -18015,7 +18143,7 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@11.0.0(@nuxt/kit@3.16.2(magicast@0.3.5))(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)):
+  vite-plugin-inspect@11.0.0(@nuxt/kit@3.16.2(magicast@0.3.5))(supports-color@9.4.0)(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)):
     dependencies:
       ansis: 3.17.0
       debug: 4.4.0(supports-color@9.4.0)
@@ -18036,7 +18164,7 @@ snapshots:
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.4
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
       vite: 6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
@@ -18067,11 +18195,11 @@ snapshots:
   vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.2
-      fdir: 6.4.3(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.3
-      rollup: 4.40.0
-      tinyglobby: 0.2.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.46.3
+      tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 22.14.1
       fsevents: 2.3.3
@@ -18084,11 +18212,11 @@ snapshots:
   vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.2
-      fdir: 6.4.3(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.3
-      rollup: 4.40.0
-      tinyglobby: 0.2.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.46.3
+      tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 24.3.0
       fsevents: 2.3.3
@@ -18115,7 +18243,7 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.8.1
 
-  vitepress-plugin-search@1.0.4-alpha.22(flexsearch@0.7.43)(vitepress@1.6.3(@algolia/client-search@5.23.4)(@types/node@22.14.1)(change-case@5.4.4)(fuse.js@7.1.0)(jwt-decode@4.0.0)(postcss@8.4.35)(sass@1.86.3)(search-insights@2.17.3)(terser@5.39.0)(typescript@5.8.3))(vue@3.5.13(typescript@5.8.3)):
+  vitepress-plugin-search@1.0.4-alpha.22(flexsearch@0.7.43)(vitepress@1.6.3(@algolia/client-search@5.23.4)(@types/node@22.14.1)(change-case@5.4.4)(fuse.js@7.1.0)(jwt-decode@4.0.0)(postcss@8.4.35)(sass@1.86.3)(search-insights@2.17.3)(terser@5.39.0)(typescript@5.8.3))(vue@3.5.25(typescript@5.8.3)):
     dependencies:
       '@types/flexsearch': 0.7.6
       '@types/markdown-it': 12.2.3
@@ -18123,7 +18251,7 @@ snapshots:
       glob-to-regexp: 0.4.1
       markdown-it: 13.0.2
       vitepress: 1.6.3(@algolia/client-search@5.23.4)(@types/node@22.14.1)(change-case@5.4.4)(fuse.js@7.1.0)(jwt-decode@4.0.0)(postcss@8.4.35)(sass@1.86.3)(search-insights@2.17.3)(terser@5.39.0)(typescript@5.8.3)
-      vue: 3.5.13(typescript@5.8.3)
+      vue: 3.5.25(typescript@5.8.3)
 
   vitepress@1.6.3(@algolia/client-search@5.23.4)(@types/node@22.14.1)(change-case@5.4.4)(fuse.js@7.1.0)(jwt-decode@4.0.0)(postcss@8.4.35)(sass@1.86.3)(search-insights@2.17.3)(terser@5.39.0)(typescript@5.8.3):
     dependencies:
@@ -18174,7 +18302,7 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@12.10.3)(sass@1.86.3)(terser@5.39.0):
+  vitest@2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@12.10.3)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.18(@types/node@24.3.0)(sass@1.86.3)(terser@5.39.0))
@@ -18186,7 +18314,7 @@ snapshots:
       chai: 5.2.0
       debug: 4.4.0(supports-color@9.4.0)
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 1.1.2
       std-env: 3.9.0
       tinybench: 2.9.0
@@ -18194,7 +18322,7 @@ snapshots:
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
       vite: 5.4.18(@types/node@24.3.0)(sass@1.86.3)(terser@5.39.0)
-      vite-node: 2.1.9(@types/node@24.3.0)(sass@1.86.3)(terser@5.39.0)
+      vite-node: 2.1.9(@types/node@24.3.0)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.3.0
@@ -18211,7 +18339,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.1.2(@types/node@24.3.0)(happy-dom@12.10.3)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
+  vitest@3.1.2(@types/node@24.3.0)(happy-dom@12.10.3)(jiti@2.4.2)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 3.1.2
       '@vitest/mocker': 3.1.2(vite@6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1))
@@ -18232,7 +18360,7 @@ snapshots:
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
       vite: 6.3.0(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
-      vite-node: 3.1.2(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
+      vite-node: 3.1.2(@types/node@24.3.0)(jiti@2.4.2)(sass@1.86.3)(supports-color@9.4.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.3.0
@@ -18265,12 +18393,16 @@ snapshots:
     dependencies:
       vue: 3.5.13(typescript@5.9.2)
 
+  vue-demi@0.14.10(vue@3.5.25(typescript@5.9.2)):
+    dependencies:
+      vue: 3.5.25(typescript@5.9.2)
+
   vue-devtools-stub@0.1.0: {}
 
-  vue-eslint-parser@9.4.3(eslint@9.25.0(jiti@2.4.2)):
+  vue-eslint-parser@9.4.3(eslint@9.25.0(jiti@2.4.2)(supports-color@9.4.0)):
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
-      eslint: 9.25.0(jiti@2.4.2)
+      eslint: 9.25.0(jiti@2.4.2)(supports-color@9.4.0)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
@@ -18348,7 +18480,7 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@17.4.2(@vue/compiler-sfc@3.5.13)(vue@3.5.13(typescript@5.8.3))(webpack@5.90.3):
+  vue-loader@17.4.2(@vue/compiler-sfc@3.5.13)(vue@3.5.25(typescript@5.8.3))(webpack@5.90.3):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
@@ -18356,7 +18488,7 @@ snapshots:
       webpack: 5.90.3
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.13
-      vue: 3.5.13(typescript@5.8.3)
+      vue: 3.5.25(typescript@5.8.3)
 
   vue-router@4.5.0(vue@3.5.13(typescript@5.8.3)):
     dependencies:
@@ -18462,7 +18594,7 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.90.3
 
-  webpack-dev-server@4.15.1(debug@4.3.4)(webpack@5.90.3):
+  webpack-dev-server@4.15.1(debug@4.3.4)(supports-color@9.4.0)(webpack@5.90.3):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -18491,7 +18623,7 @@ snapshots:
       selfsigned: 2.4.1
       serve-index: 1.9.1
       sockjs: 0.3.24
-      spdy: 4.0.2
+      spdy: 4.0.2(supports-color@9.4.0)
       webpack-dev-middleware: 5.3.3(webpack@5.90.3)
       ws: 8.16.0
     optionalDependencies:
@@ -18517,16 +18649,16 @@ snapshots:
   webpack@5.90.3:
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@webassemblyjs/ast': 1.11.6
       '@webassemblyjs/wasm-edit': 1.11.6
       '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.11.3
-      acorn-import-assertions: 1.9.0(acorn@8.11.3)
-      browserslist: 4.23.0
+      acorn: 8.14.1
+      acorn-import-assertions: 1.9.0(acorn@8.14.1)
+      browserslist: 4.24.4
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.4.1
+      enhanced-resolve: 5.18.1
+      es-module-lexer: 1.6.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -18548,16 +18680,16 @@ snapshots:
   webpack@5.90.3(esbuild@0.25.2):
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@webassemblyjs/ast': 1.11.6
       '@webassemblyjs/wasm-edit': 1.11.6
       '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.11.3
-      acorn-import-assertions: 1.9.0(acorn@8.11.3)
-      browserslist: 4.23.0
+      acorn: 8.14.1
+      acorn-import-assertions: 1.9.0(acorn@8.14.1)
+      browserslist: 4.24.4
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.4.1
+      enhanced-resolve: 5.18.1
+      es-module-lexer: 1.6.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
   - 'packages/*'
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  unrs-resolver: true
+  vue-demi: true


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `@teamnovu/kit-operations` package for TanStack Query endpoint definitions
- Introduces a new workspace package [`packages/operations`](https://github.com/teamnovu/kit/pull/16/files#diff-20023a3494f39c8b6fb1f880a60ffd9e618754aff2a8116d8d830406abccbc71) that provides a fluent DSL for defining typed query and mutation endpoints backed by TanStack Query.
- Query endpoints (`query.build`) produce `QueryOptions` with hierarchical `queryKey` composition, URL param interpolation, and automatic resource tracking for cache invalidation.
- Mutation endpoints (`mutation.build`) produce `MutationOptions` with URL interpolation and optional params transforms.
- A `resourceRegistry` tracks which queries returned which JSON-LD resources, enabling `invalidateResources()` to invalidate queries by resource type or instance without knowing the original query keys.
- Transport (custom fetch/mutation adapter) is resolved via Vue `provide`/`inject` or a global `setTransport()` fallback, throwing a descriptive error if neither is configured.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2540317.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->